### PR TITLE
[Vue] added persistence to expansion panels state in Document Viewer

### DIFF
--- a/demo/vue-viewer/src/components/ElementInspector.vue
+++ b/demo/vue-viewer/src/components/ElementInspector.vue
@@ -1,12 +1,12 @@
 <template>
 	<div class="v-application v-application--is-ltr PageInspector">
-		<v-expansion-panels :value="0">
+		<v-expansion-panels v-model="elementInspectorSwitch">
 			<v-expansion-panel>
-				<v-expansion-panel-header
-					><header>
+				<v-expansion-panel-header>
+					<header>
 						<h1>Element inspector</h1>
-					</header></v-expansion-panel-header
-				>
+					</header>
+				</v-expansion-panel-header>
 				<v-expansion-panel-content>
 					<div class="PageInspectorContainer">
 						<v-icon v-if="!currentElement" size="40" color="#cccccc" style="margin-top:10px;"
@@ -46,6 +46,7 @@
 </template>
 
 <script>
+import { mapMutations, mapGetters } from 'vuex';
 export default {
 	props: {
 		pageElements: {
@@ -66,11 +67,21 @@ export default {
 		},
 	},
 	computed: {
+		...mapGetters(['elementInspectorSwitchState']),
+		elementInspectorSwitch: {
+			get() {
+				return this.elementInspectorSwitchState;
+			},
+			set(value) {
+				this.switchExpansionPanel({ panel: 'elementInspector', value });
+			},
+		},
 		currentElement() {
 			return this.selectedParentElement ? this.selectedParentElement : this.selectedElement;
 		},
 	},
 	methods: {
+		...mapMutations(['switchExpansionPanel']),
 		fontInfo(fontId) {
 			const font = this.fonts.filter(font => font.id === fontId).shift();
 			if (font) {

--- a/demo/vue-viewer/src/components/ElementSelector.vue
+++ b/demo/vue-viewer/src/components/ElementSelector.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="v-application v-application--is-ltr ElementSelector">
-		<v-expansion-panels :value="0">
+		<v-expansion-panels v-model="elementSelectorSwitch">
 			<v-expansion-panel>
 				<v-expansion-panel-header>
 					<header>
@@ -25,7 +25,7 @@
 	</div>
 </template>
 <script>
-import { mapMutations, mapState } from 'vuex';
+import { mapMutations, mapState, mapGetters } from 'vuex';
 export default {
 	props: {
 		pageElements: {
@@ -34,7 +34,7 @@ export default {
 		},
 	},
 	methods: {
-		...mapMutations(['setElementSelected']),
+		...mapMutations(['setElementSelected', 'switchExpansionPanel']),
 		selectedElementEvent(element) {
 			// removes all other highlighted elements when this selector is used
 			const highlightedElements = document.getElementsByClassName('highlighted');
@@ -77,6 +77,15 @@ export default {
 	},
 	computed: {
 		...mapState(['selectedElement']),
+		...mapGetters(['elementSelectorSwitchState']),
+		elementSelectorSwitch: {
+			get() {
+				return this.elementSelectorSwitchState;
+			},
+			set(value) {
+				this.switchExpansionPanel({ panel: 'elementSelector', value });
+			},
+		},
 		items() {
 			return this.pageElements
 				.map(this.flatten)

--- a/demo/vue-viewer/src/components/PageInspector.vue
+++ b/demo/vue-viewer/src/components/PageInspector.vue
@@ -1,12 +1,12 @@
 <template>
 	<div class="v-application v-application--is-ltr PageInspector">
-		<v-expansion-panels :value="0">
+		<v-expansion-panels v-model="pageInspectorSwitch">
 			<v-expansion-panel>
-				<v-expansion-panel-header
-					><header>
+				<v-expansion-panel-header>
+					<header>
 						<h1>Visibility Filters</h1>
-					</header></v-expansion-panel-header
-				>
+					</header>
+				</v-expansion-panel-header>
 				<v-expansion-panel-content>
 					<div class="PageInspectorContainer">
 						<v-switch
@@ -57,6 +57,7 @@
 </template>
 
 <script>
+import { mapGetters, mapMutations } from 'vuex';
 export default {
 	data() {
 		return {
@@ -73,7 +74,19 @@ export default {
 			required: true,
 		},
 	},
+	computed: {
+		...mapGetters(['pageInspectorSwitchState']),
+		pageInspectorSwitch: {
+			get() {
+				return this.pageInspectorSwitchState;
+			},
+			set(value) {
+				this.switchExpansionPanel({ panel: 'pageInspector', value });
+			},
+		},
+	},
 	methods: {
+		...mapMutations(['switchExpansionPanel']),
 		swapFilters() {
 			const newFilters = {
 				words: this.wordsFilter,

--- a/demo/vue-viewer/src/components/WordHierarchy.vue
+++ b/demo/vue-viewer/src/components/WordHierarchy.vue
@@ -1,34 +1,43 @@
 <template>
-	<div v-if="selectedElement" class="PageInspector">
-		<header>
-			<h1>Word hierarchy</h1>
-		</header>
-		<div class="PageInspectorContainer">
-			<v-treeview
-				v-if="selectedElement"
-				:items="items"
-				:open="openItems"
-				:active="activeItem"
-				:dense="true"
-				:transition="true"
-				style="text-align:left"
-				:open-all="true"
-				activatable
-				color="f9f9fd"
-				@update:active="onActiveUpdated"
-			>
-				<!--template v-slot:label="{ item, active }">
+	<div v-if="selectedElement" class="v-application v-application--is-ltr PageInspector">
+		<v-expansion-panels v-model="wordHierarchySwitch">
+			<v-expansion-panel>
+				<v-expansion-panel-header>
+					<header>
+						<h1>Word hierarchy</h1>
+					</header>
+				</v-expansion-panel-header>
+				<v-expansion-panel-content>
+					<div class="PageInspectorContainer">
+						<v-treeview
+							v-if="selectedElement"
+							:items="items"
+							:open="openItems"
+							:active="activeItem"
+							:dense="true"
+							:transition="true"
+							style="text-align:left"
+							:open-all="true"
+							activatable
+							color="f9f9fd"
+							@update:active="onActiveUpdated"
+						>
+							<!--template v-slot:label="{ item, active }">
 					<span>{{ item.name }}</span>
 					<v-icon v-if="active" size="20" style="margin-left:10px" title="Inspected">
 						mdi-crosshairs
 					</v-icon>
-				</template-->
-			</v-treeview>
-		</div>
+							</template-->
+						</v-treeview>
+					</div>
+				</v-expansion-panel-content>
+			</v-expansion-panel>
+		</v-expansion-panels>
 	</div>
 </template>
 
 <script>
+import { mapGetters, mapMutations } from 'vuex';
 export default {
 	data() {
 		return {
@@ -68,6 +77,7 @@ export default {
 		},
 	},
 	methods: {
+		...mapMutations(['switchExpansionPanel']),
 		capitalize(string) {
 			return string.charAt(0).toUpperCase() + string.slice(1);
 		},
@@ -153,9 +163,19 @@ export default {
 			return null;
 		},
 	},
+	computed: {
+		...mapGetters(['wordHierarchySwitchState']),
+		wordHierarchySwitch: {
+			get() {
+				return this.wordHierarchySwitchState;
+			},
+			set(value) {
+				this.switchExpansionPanel({ panel: 'wordHierarchy', value });
+			},
+		},
+	},
 };
 </script>
-
 <style lang="scss" scoped>
 .PageInspector {
 	text-align: center;
@@ -165,6 +185,7 @@ export default {
 	background-color: #ebebf1;
 	color: #2c3034;
 	text-align: left;
+	padding: 5px 0px;
 }
 .PageInspector header h1 {
 	font-size: 1em;
@@ -176,25 +197,33 @@ export default {
 	display: inline-block;
 	vertical-align: middle;
 }
-.PageInspectorContainer span.noSelection {
-	display: block;
-	margin: 10px 20px;
-}
-.PageInspectorContainer .elementProperties {
-	list-style-type: none;
-	padding-left: 0;
+
+.switch {
+	border-bottom: 1px solid #ebebf1;
 	margin: 0;
+	padding: 10px;
 }
-.PageInspectorContainer .elementProperties li {
-	text-align: left;
-	border-bottom: solid 1px #ebebf1;
-	padding: 8px 0 8px 8px;
+
+div.v-expansion-panels div.v-expansion-panel {
+	background-color: transparent;
 }
-.PageInspectorContainer .elementProperties li span {
-	color: #6c6c6c;
+div.v-expansion-panels div.v-expansion-panel:before {
+	box-shadow: none;
 }
-.PageInspectorContainer .elementProperties li ul li {
-	border: 0;
+div.v-expansion-panels button.v-expansion-panel-header {
+	padding: 0;
+	min-height: 0;
+	color: rgba(0, 0, 0, 0.54);
+	background-color: #ebebf1;
+	border-radius: 0;
+}
+
+div.v-expansion-panels button.v-expansion-panel-header .v-icon {
+	color: rgba(0, 0, 0, 0.24) !important;
+}
+</style>
+<style lang="scss">
+.PageInspector div.v-expansion-panels div.v-expansion-panel-content__wrap {
 	padding: 0;
 }
 </style>

--- a/demo/vue-viewer/src/vuex/store.js
+++ b/demo/vue-viewer/src/vuex/store.js
@@ -12,6 +12,13 @@ export default new Vuex.Store({
 		inputFileName: null,
 		document: null,
 		inspectorFilters: {},
+		expansionPanels: {
+			// 0: panel opened, undefined: panel closed
+			pageInspector: 0,
+			elementSelector: 0,
+			elementInspector: 0,
+			wordHierarchy: 0,
+		},
 		selectedElement: null,
 		selectedParentElement: null,
 		outputs: {
@@ -213,6 +220,9 @@ export default new Vuex.Store({
 		SET_DOCUMENT_ID(state, id) {
 			state.uuid = id;
 		},
+		switchExpansionPanel(state, { panel, value }) {
+			state.expansionPanels[panel] = value;
+		},
 	},
 	actions: {
 		fetchThumbnail({ commit }, { page }) {
@@ -293,6 +303,18 @@ export default new Vuex.Store({
 		},
 		wordFont: state => fontId => {
 			return state.document.fonts.filter(font => font.id === fontId).shift();
+		},
+		pageInspectorSwitchState(state) {
+			return state.expansionPanels.pageInspector;
+		},
+		elementSelectorSwitchState(state) {
+			return state.expansionPanels.elementSelector;
+		},
+		elementInspectorSwitchState(state) {
+			return state.expansionPanels.elementInspector;
+		},
+		wordHierarchySwitchState(state) {
+			return state.expansionPanels.wordHierarchy;
 		},
 	},
 });


### PR DESCRIPTION
The expansion panels in Document Viewer now mantain their state (expanded / closed) when switching between tabs