### PR TITLE
Make `npm run format` windows compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"start:api:background": "npm run start:api&",
 		"start:front": "cd demo/web-viewer && node index.js",
 		"start": "npm run start:api & npm run start:front",
-		"format": "prettier --write --list-different '{,!(dist|demo/web-viewer/public)/**/}*.{js,md,ts,css,scss}'"
+		"format": "prettier --write --list-different \"{,!(dist|demo/web-viewer/public)/**/}*.{js,md,ts,css,scss}\""
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
The single quotes in the npm script made them non-compatible under windows.
Just fixed that with escaped double-quotes.