### PR TITLE
Resolves #82 : Adding default configuration retrieval possible using the API

### DIFF
--- a/api/server/src/ServerManager.ts
+++ b/api/server/src/ServerManager.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+
+export class ServerManager {
+	public getDefaultConfig(): object {
+		const configPath: string = `../../server/defaultConfig.json`;
+		const defaultConfig: object = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		return defaultConfig;
+	}
+}

--- a/api/server/src/api.ts
+++ b/api/server/src/api.ts
@@ -24,12 +24,14 @@ import * as path from 'path';
 import { FileManager } from './FileManager';
 import logger from './Logger';
 import { ProcessManager } from './ProcessManager';
+import { ServerManager } from './ServerManager';
 import { Binder, PipelineProcess, QueueStatus, SingleFileType } from './types';
 
 export class ApiServer {
 	private outputDir: string = path.resolve(`${__dirname}/output`);
 	private fileManager: FileManager = new FileManager();
 	private processManager: ProcessManager = new ProcessManager();
+	private serverManager: ServerManager = new ServerManager();
 
 	private upload = multer({
 		storage: multer.diskStorage({
@@ -86,9 +88,31 @@ export class ApiServer {
 		// TODO add every other endpoint
 		v1_0.get('/thumbnail/:id/:page', this.handleGetThumb.bind(this));
 
+		// server info endpoints
+		v1_0.get('/default-config', this.handleGetDefaultConfig.bind(this));
+
 		app.listen(port, () => {
 			logger.info(`Api listening on port ${port}!`);
 		});
+	}
+
+	/**
+	 * Status: 200 - Ok. Returns the default config of the server
+	 * Status: 404 - Not Found - the default server config was not found in the pre-set location
+	 */
+	private handleGetDefaultConfig(req: Request, res: Response): void {
+		res.setHeader('Access-Control-Allow-Origin', '*');
+
+		let defaultConfig: object;
+		try {
+			defaultConfig = this.serverManager.getDefaultConfig();
+		} catch (err) {
+			logger.warn(`Cannot get default server settings: ${err}`);
+			res.sendStatus(404);
+			return;
+		}
+		logger.info(`Returning the default server settings...`);
+		res.status(200).json(defaultConfig);
 	}
 
 	/**


### PR DESCRIPTION
Citing #82:

> **Description**
> Currently, the default server configuration is supplied along with the project source.
> In a deployed environment, the client cannot be automatically notified if the server's defaults are changed.
> An API endpoint /default-config could provide this information, which would remove the need to hardcode anything on the client/GUI side.
> 
> EDIT: changed the proposition from /defaultConfig to /default-config to follow api endpoint naming convention.