### PR TITLE
Improved Table detection

### DIFF
--- a/server/assets/TableDetectionScript.py
+++ b/server/assets/TableDetectionScript.py
@@ -128,12 +128,13 @@ def main():
     import sys
     pdfFile = str(sys.argv[1])
     flavor = str(sys.argv[2])
+    lineScale = int(sys.argv[3])
 
     pages = 'all'
-    if len(sys.argv) > 3:
-        pages = str(sys.argv[3])
+    if len(sys.argv) > 4:
+        pages = str(sys.argv[4])
 
-    tables = camelot.read_pdf(pdfFile, pages, None, flavor)
+    tables = camelot.read_pdf(pdfFile,  pages=pages, flavor=flavor, line_scale=lineScale)
 
     if len(tables) == 0:
         #print('No tables detected ', tables)

--- a/server/src/processing/TableDetectionModule/TableDetectionModule.ts
+++ b/server/src/processing/TableDetectionModule/TableDetectionModule.ts
@@ -215,7 +215,15 @@ export class TableDetectionModule extends Module<Options> {
 	}
 
 	private wordsInCellBox(cellBounds: BoundingBox, pageWords: Word[]): Word[] {
-		return pageWords.filter(word => utils.isInBox(word, cellBounds, false));
+		const isInBox = (element, box) => {
+			return (
+				element.box.top + element.box.height * 0.2 >= box.top &&
+				element.box.top + element.box.height <= box.top + box.height &&
+				element.box.left >= box.left &&
+				element.box.left + element.box.width <= box.left + box.width
+			);
+		};
+		return pageWords.filter(word => isInBox(word, cellBounds));
 	}
 
 	private removeWordsUsedInCells(document: Document) {

--- a/server/src/processing/TableDetectionModule/TableDetectionModule.ts
+++ b/server/src/processing/TableDetectionModule/TableDetectionModule.ts
@@ -39,6 +39,7 @@ const defaultExtractor: TableExtractor = {
 	readTables(inputFile: string, options: Options): TableExtractorResult {
 		let pages: string = 'all';
 		let flavor: string = 'lattice';
+		const lineScale: string = '70';
 		if (options.pages.value.length !== 0) {
 			pages = options.pages.value.toString();
 		}
@@ -69,6 +70,7 @@ const defaultExtractor: TableExtractor = {
 			__dirname + '/../../../assets/TableDetectionScript.py',
 			inputFile,
 			flavor,
+			lineScale,
 			pages,
 		]);
 


### PR DESCRIPTION
In some cases table lines are not properly detected and we need to configure camelot in order to be more precise in table lines detection [(Camelot short lines parameter)](https://camelot-py.readthedocs.io/en/master/user/advanced.html#detect-short-lines).


Before (last row missing 1 cell)
<img width="690" alt="Screenshot 2019-10-17 at 15 23 04" src="https://user-images.githubusercontent.com/12429149/67012807-54627000-f0f2-11e9-8c88-1950b609f181.png">

After (last row with 2 cells)
<img width="697" alt="Screenshot 2019-10-17 at 15 22 04" src="https://user-images.githubusercontent.com/12429149/67012824-59bfba80-f0f2-11e9-8eb0-8cf880a5b18d.png">


Also added tolerance when finding words in cell box because some times words box are not perfect fitted into cell box

<img width="443" alt="Screenshot 2019-10-17 at 15 28 09" src="https://user-images.githubusercontent.com/12429149/67013039-bde27e80-f0f2-11e9-8ce7-8adbda5bd7b2.png">
