### PR TITLE
Feature/default config simplification

### DIFF
--- a/api/server/package-lock.json
+++ b/api/server/package-lock.json
@@ -40,11 +40,6 @@
 				"@types/range-parser": "*"
 			}
 		},
-		"@types/lodash": {
-			"version": "4.14.144",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
-			"integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg=="
-		},
 		"@types/mime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -462,11 +457,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
 			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
-		},
-		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"media-typer": {
 			"version": "0.3.0",

--- a/api/server/package.json
+++ b/api/server/package.json
@@ -14,11 +14,9 @@
 	"author": "Sacha Bron",
 	"license": "ISC",
 	"dependencies": {
-		"@types/lodash": "^4.14.144",
 		"@types/multer": "^1.3.7",
 		"commander": "^2.19.0",
 		"express": "^4.16.4",
-		"lodash": "^4.17.15",
 		"multer": "^1.4.1",
 		"pino": "^5.12.0",
 		"pino-pretty": "^2.6.0"

--- a/api/server/src/ServerManager.ts
+++ b/api/server/src/ServerManager.ts
@@ -15,8 +15,6 @@
  */
 
 import { readdirSync, readFileSync } from 'fs';
-import deepMerge from 'lodash/fp/merge';
-
 export interface ConfigFile {
 	version: number;
 	extractor: object;
@@ -72,22 +70,15 @@ export class ServerManager {
 
 	private fillModuleWithSpecs(mod: object): object {
 		const [moduleName, customConfig] = Array.isArray(mod) ? mod : [mod, {}];
-		/*
-			this will be refactored in the next iteration,
-			where I won't have to remove the name and description values
-			(specs will not be on the same level)
-		*/
-		const moduleConfig = JSON.parse(
-			JSON.stringify({
-				...this.getModuleConfig(moduleName),
-				name: undefined,
-				description: undefined,
-			}),
-		);
 
-		const mergedResult = [moduleName, deepMerge(moduleConfig, customConfig)].filter(
-			d => typeof d !== 'object' || Object.keys(d).length > 0,
-		);
+		const { specs } = this.getModuleConfig(moduleName) as any;
+
+		// merges custom parameter values with the value in the module specs
+		Object.keys(customConfig).forEach(key => {
+			specs[key].value = customConfig[key];
+		});
+
+		const mergedResult = [moduleName, specs].filter(m => !!m);
 
 		// if length === 2, config has parameters. if not, i return only the module name as a string
 		return mergedResult.length === 2 ? mergedResult : mergedResult[0];

--- a/demo/vue-viewer/src/views/Upload.vue
+++ b/demo/vue-viewer/src/views/Upload.vue
@@ -101,8 +101,31 @@ export default {
 		isSubmitDisabled() {
 			return !this.file;
 		},
+		/* 
+			this function takes the config in 'specs' format and returns only the values of each parameter
+			ex:
+				parameter: {
+					value: 'foo',
+					range: ['foo', 'bar']
+				}
+
+			returns parameter: 'foo'
+		*/
+		keyValueConfig() {
+			// i have to make sure to clone the values and not the references of the configs
+			const config = JSON.parse(JSON.stringify({ ...this.defaultConfig, ...this.customConfig }));
+			config.cleaner = config.cleaner.map(mod => {
+				if (Array.isArray(mod)) {
+					Object.keys(mod[1]).forEach(key => {
+						mod[1][key] = mod[1][key].value;
+					});
+				}
+				return mod;
+			});
+			return config;
+		},
 		configAsBinary() {
-			var data = this.encode(JSON.stringify({ ...this.defaultConfig, ...this.customConfig }));
+			var data = this.encode(JSON.stringify(this.keyValueConfig));
 			return new Blob([data], {
 				type: 'application/json',
 			});

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -90,8 +90,8 @@ Module can be called in the full form:
 [
 	"module",
 	{
-		"option-1": { "value": 100 },
-		"option-2": { "value": true }
+		"option-1": 100,
+		"option-2": true
 	}
 ],
 ```
@@ -149,32 +149,30 @@ The `includeMarginals: boolean` parameter allows to chose whether the output wil
 		"whitespace-removal",
 		"redundancy-detection",
 		"table-detection",
-		["header-footer-detection", { "maxMarginPercentage": { "value": 15 } }],
-		["reading-order-detection", { "minColumnWidthInPagePercent": { "value": 15 } }],
+		["header-footer-detection", { "maxMarginPercentage": 15 }],
+		["reading-order-detection", { "minColumnWidthInPagePercent": 15 } ],
 		"link-detection",
-		["words-to-line", { "maximumSpaceBetweenWords": { "value": 100 } }],
+		["words-to-line", { "maximumSpaceBetweenWords": 100 }],
 		"lines-to-paragraph",
-		["page-number-detection", { "maxMarginPercentage": { "value": 15 } }],
+		["page-number-detection", { "maxMarginPercentage": 15 }],
 		"hierarchy-detection",
 		[
 			"regex-matcher",
 			{
-				"queries": {
-					"value": [
-						{
-							"label": "Car",
-							"regex": "([A-Z]{2}\\-[\\d]{3}\\-[A-Z]{2})"
-						},
-						{
-							"label": "Age",
-							"regex": "(\\d+)[ -]*(ans|jarige)"
-						},
-						{
-							"label": "Percent",
-							"regex": "([\\-]?(\\d)+[\\.\\,]*(\\d)*)[ ]*(%|per|percent|pourcent|procent)"
-						}
-					]
-				}
+				"queries": [
+					{
+						"label": "Car",
+						"regex": "([A-Z]{2}\\-[\\d]{3}\\-[A-Z]{2})"
+					},
+					{
+						"label": "Age",
+						"regex": "(\\d+)[ -]*(ans|jarige)"
+					},
+					{
+						"label": "Percent",
+						"regex": "([\\-]?(\\d)+[\\.\\,]*(\\d)*)[ ]*(%|per|percent|pourcent|procent)"
+					}
+				]
 			}
 		]
 	],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	},
 	"husky": {
 		"hooks": {
+			"pre-commit": "lint-staged && npm test && npm audit",
 			"pre-push": "npm test && npm audit"
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "lint-staged && npm test && npm audit",
 			"pre-push": "npm test && npm audit"
 		}
 	},

--- a/server/configKeyValueSearch.json
+++ b/server/configKeyValueSearch.json
@@ -10,12 +10,12 @@
 		"whitespace-removal",
 		"redundancy-detection",
 		"table-detection",
-		["header-footer-detection", { "maxMarginPercentage": { "value": 15 } }],
-		["reading-order-detection", { "minColumnWidthInPagePercent": { "value": 15 } }],
+		["header-footer-detection", { "maxMarginPercentage": 15 }],
+		["reading-order-detection", { "minColumnWidthInPagePercent": 15 }],
 		"link-detection",
-		["words-to-line", { "maximumSpaceBetweenWords": { "value": 100 } }],
+		["words-to-line", { "maximumSpaceBetweenWords": 100 }],
 		"lines-to-paragraph",
-		["page-number-detection", { "maxMarginPercentage": { "value": 15 } }],
+		["page-number-detection", { "maxMarginPercentage": 15 }],
 		"hierarchy-detection",
 		[
 			"key-value-detection",
@@ -96,22 +96,20 @@
 		[
 			"regex-matcher",
 			{
-				"queries": {
-					"value": [
-						{
-							"label": "Car",
-							"regex": "([A-Z]{2}\\-[\\d]{3}\\-[A-Z]{2})"
-						},
-						{
-							"label": "Age",
-							"regex": "(\\d+)[ -]*(ans|jarige)"
-						},
-						{
-							"label": "Percent",
-							"regex": "([\\-]?(\\d)+[\\.\\,]*(\\d)*)[ ]*(%|per|percent|pourcent|procent)"
-						}
-					]
-				}
+				"queries": [
+					{
+						"label": "Car",
+						"regex": "([A-Z]{2}\\-[\\d]{3}\\-[A-Z]{2})"
+					},
+					{
+						"label": "Age",
+						"regex": "(\\d+)[ -]*(ans|jarige)"
+					},
+					{
+						"label": "Percent",
+						"regex": "([\\-]?(\\d)+[\\.\\,]*(\\d)*)[ ]*(%|per|percent|pourcent|procent)"
+					}
+				]
 			}
 		]
 	],

--- a/server/defaultConfig.json
+++ b/server/defaultConfig.json
@@ -13,118 +13,79 @@
 		[
 			"whitespace-removal",
 			{
-				"minWidth": {
-					"value": 0
-				}
+				"minWidth": 10
 			}
 		],
 		[
 			"redundancy-detection",
 			{
-				"minOverlap": {
-					"value": 0.5
-				},
-				"minimumPages": {
-					"value": 6
-				}
+				"minOverlap": 0.5
 			}
 		],
 		[
 			"table-detection",
 			{
-				"pages": {
-					"value": []
-				},
-				"flavor": {
-					"value": "lattice"
-				}
+				"pages": [],
+				"flavor": "lattice"
 			}
 		],
 		[
 			"header-footer-detection",
 			{
-				"ignorePages": {
-					"value": []
-				},
-				"maxMarginPercentage": {
-					"value": 15
-				}
+				"ignorePages": [],
+				"maxMarginPercentage": 15
 			}
 		],
 		[
 			"reading-order-detection",
 			{
-				"minVerticalGapWidth": {
-					"value": 5
-				},
-				"minColumnWidthInPagePercent": {
-					"value": 15
-				}
+				"minVerticalGapWidth": 5,
+				"minColumnWidthInPagePercent": 15
 			}
 		],
 		"link-detection",
 		[
 			"words-to-line",
 			{
-				"lineHeightUncertainty": {
-					"value": 0.2
-				},
-				"topUncertainty": {
-					"value": 0.4
-				},
-				"maximumSpaceBetweenWords": {
-					"value": 100
-				},
-				"mergeTableElements": {
-					"value": false
-				}
+				"lineHeightUncertainty": 0.2,
+				"topUncertainty": 0.4,
+				"maximumSpaceBetweenWords": 100,
+				"mergeTableElements": false
 			}
 		],
 		[
 			"lines-to-paragraph",
 			{
-				"tolerance": {
-					"value": 0.25
-				}
+				"tolerance": 0.25
 			}
 		],
 		[
 			"page-number-detection",
 			{
-				"ignorePages": {
-					"value": []
-				},
-				"maxMarginPercentage": {
-					"value": 15
-				}
+				"ignorePages": [],
+				"maxMarginPercentage": 15
 			}
 		],
 		"hierarchy-detection",
 		[
 			"regex-matcher",
 			{
-				"isCaseSensitive": {
-					"value": true
-				},
-				"isGlobal": {
-					"value": true
-				},
-				"queries": {
-					"value": [
-						{
-							"label": "Car",
-							"regex": "([A-Z]{2}\\-[\\d]{3}\\-[A-Z]{2})"
-						},
-						{
-							"label": "Age",
-							"regex": "(\\d+)[ -]*(ans|jarige)"
-						},
-						{
-							"label": "Percent",
-							"regex": "([\\-]?(\\d)+[\\.\\,]*(\\d)*)[ ]*(%|per|percent|pourcent|procent)"
-						}
-					]
-				}
+				"isCaseSensitive": true,
+				"isGlobal": true,
+				"queries": [
+					{
+						"label": "Car",
+						"regex": "([A-Z]{2}\\-[\\d]{3}\\-[A-Z]{2})"
+					},
+					{
+						"label": "Age",
+						"regex": "(\\d+)[ -]*(ans|jarige)"
+					},
+					{
+						"label": "Percent",
+						"regex": "([\\-]?(\\d)+[\\.\\,]*(\\d)*)[ ]*(%|per|percent|pourcent|procent)"
+					}
+				]
 			}
 		]
 	],

--- a/server/defaultConfig.json
+++ b/server/defaultConfig.json
@@ -13,7 +13,7 @@
 		[
 			"whitespace-removal",
 			{
-				"minWidth": 10
+				"minWidth": 0
 			}
 		],
 		[

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -32,16 +32,8 @@ import * as defaultConfig from './defaultConfig.json';
  * from https://english.stackexchange.com/a/25105
  */
 interface Options {
-	ignorePages?: {
-		value: number[];
-	};
-	maxMarginPercentage?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
+	ignorePages?: number[];
+	maxMarginPercentage?: number;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -68,7 +60,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 					'the document only has 1 page (not enough data).',
 			);
 			return doc;
-		} else if (this.options.maxMarginPercentage.value === undefined) {
+		} else if (this.options.maxMarginPercentage === undefined) {
 			logger.info(
 				'Not computing marginals (headers and footers); maxMarginPercentage setting not found in the configuration.',
 			);
@@ -81,7 +73,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 		}
 		logger.info(
 			'Detecting marginals (headers and footers) with maxMarginPercentage:',
-			this.options.maxMarginPercentage.value,
+			this.options.maxMarginPercentage,
 			'...',
 		);
 
@@ -97,7 +89,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 		}
 
 		doc.pages
-			.filter(p => !this.options.ignorePages.value.includes(p))
+			.filter(p => !this.options.ignorePages.includes(p))
 			.forEach(page => {
 				const h: number[] = page.horizontalOccupancy.map(boolToInt);
 				occupancyAcrossHeight = utils.addVectors(occupancyAcrossHeight, h);
@@ -121,7 +113,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 			});
 
 		const maxT: number = Math.floor(
-			0 + (this.options.maxMarginPercentage.value * occupancyAcrossHeight.length) / 100,
+			0 + (this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
 		);
 		doc.margins.top = heightZeros
 			.filter(value => value < maxT)
@@ -130,7 +122,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 			})[0];
 		const maxB: number = Math.floor(
 			occupancyAcrossHeight.length -
-				(this.options.maxMarginPercentage.value * occupancyAcrossHeight.length) / 100,
+				(this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
 		);
 		doc.margins.bottom = heightZeros
 			.filter(value => value > maxB)
@@ -138,7 +130,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 				return a - b;
 			})[0];
 		const maxL: number = Math.floor(
-			0 + (this.options.maxMarginPercentage.value * occupancyAcrossWidth.length) / 100,
+			0 + (this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
 		);
 		doc.margins.left = widthZeros
 			.filter(value => value < maxL)
@@ -147,7 +139,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 			})[0];
 		const maxR: number = Math.floor(
 			occupancyAcrossWidth.length -
-				(this.options.maxMarginPercentage.value * occupancyAcrossWidth.length) / 100,
+				(this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
 		);
 		doc.margins.right = widthZeros
 			.filter(value => value > maxR)
@@ -156,7 +148,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 			})[0];
 
 		logger.info(
-			`Document margins for maxMarginPercentage ${this.options.maxMarginPercentage.value}: ` +
+			`Document margins for maxMarginPercentage ${this.options.maxMarginPercentage}: ` +
 				`top: ${doc.margins.top}, bottom: ${doc.margins.bottom}, ` +
 				`left: ${doc.margins.left}, right: ${doc.margins.right}`,
 		);

--- a/server/src/processing/HeaderFooterDetectionModule/defaultConfig.json
+++ b/server/src/processing/HeaderFooterDetectionModule/defaultConfig.json
@@ -1,14 +1,16 @@
 {
 	"name": "header-footer-detection",
 	"description": "Detect the header and footer areas in a document, and set the appropriate properties of all the elements contained within those areas.",
-	"ignorePages": {
-		"value": []
-	},
-	"maxMarginPercentage": {
-		"value": 30,
-		"range": {
-			"min": 0,
-			"max": 100
+	"specs": {
+		"ignorePages": {
+			"value": []
+		},
+		"maxMarginPercentage": {
+			"value": 30,
+			"range": {
+				"min": 0,
+				"max": 100
+			}
 		}
 	}
 }

--- a/server/src/processing/KeyValueDetectionModule/KeyValueDetectionModule.ts
+++ b/server/src/processing/KeyValueDetectionModule/KeyValueDetectionModule.ts
@@ -24,17 +24,10 @@ import { WordsToLineModule } from '../WordsToLineModule/WordsToLineModule';
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	keyPatterns?: {
-		value: object; // object of type { keyname: Array<string> } to represent various keys and set of patterns to match
-	};
+	// object of type { keyname: Array<string> } to represent various keys and set of patterns to match
+	keyPatterns?: object;
 	keyValueDividerChars?: string[];
-	thresholdRatio?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
+	thresholdRatio?: number;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -58,16 +51,16 @@ export class KeyValueDetectionModule extends Module<Options> {
 	}
 
 	public main(doc: Document): Document {
-		if (this.options.thresholdRatio.value === undefined) {
+		if (this.options.thresholdRatio === undefined) {
 			logger.info('Not computing key-value pairs, no thresholdRatio vas specified');
 			return doc;
-		} else if (this.options.keyPatterns.value === {}) {
+		} else if (this.options.keyPatterns === {}) {
 			logger.info('The key patterns not precised. Not computing key-value pairs.');
 			return doc;
 		} else {
 			logger.info(
 				'Detecting key-value pairs, for key patterns',
-				Object.keys(this.options.keyPatterns.value),
+				Object.keys(this.options.keyPatterns),
 				'...',
 			);
 		}
@@ -79,7 +72,7 @@ export class KeyValueDetectionModule extends Module<Options> {
 			const allLines: Line[] = page.getElementsOfType<Line>(Line);
 			const allKeys: KeyCandidate[] = [];
 
-			for (const [key, patterns] of Object.entries(this.options.keyPatterns.value)) {
+			for (const [key, patterns] of Object.entries(this.options.keyPatterns)) {
 				allLines.forEach(line => {
 					if (Array.isArray(patterns)) {
 						const bestKey: KeyCandidate = patterns
@@ -87,7 +80,7 @@ export class KeyValueDetectionModule extends Module<Options> {
 								return this.findKeys(key, p, line.content).sort((a, b) => b.score - a.score)[0];
 							})
 							.filter(k => typeof k !== 'undefined' && k.words.length !== 0)
-							.filter(c => c.score > this.options.thresholdRatio.value)
+							.filter(c => c.score > this.options.thresholdRatio)
 							.reduce(this.takeBestScore, {
 								score: 0,
 								words: [],
@@ -185,7 +178,7 @@ export class KeyValueDetectionModule extends Module<Options> {
 				word.left >= keyBox.right &&
 				word.right <= nextKeyBox.left &&
 				keyCandidates.every(keyCandindate => !keyCandindate.words.includes(word)) &&
-				!this.options.keyValueDividerChars.value.includes(word.toString())
+				!this.options.keyValueDividerChars.includes(word.toString())
 			);
 		});
 	}
@@ -198,7 +191,7 @@ export class KeyValueDetectionModule extends Module<Options> {
 	 */
 	private findKeys(key, pattern: string, words: Word[]): KeyCandidate[] {
 		const filteredWords: Word[] = words.filter(
-			w => !this.options.keyValueDividerChars.value.includes(w.toString()),
+			w => !this.options.keyValueDividerChars.includes(w.toString()),
 		);
 
 		let wordCollections: Word[][] = [];
@@ -218,7 +211,7 @@ export class KeyValueDetectionModule extends Module<Options> {
 				.map(w => w.toString().trim())
 				.reduce((w1, w2) => w1 + ' ' + w2, '')
 				.trim()
-				.replace(new RegExp(`(?:\\${this.options.keyValueDividerChars.value.join('|\\')})`), '');
+				.replace(new RegExp(`(?:\\${this.options.keyValueDividerChars.join('|\\')})`), '');
 			const score: number = string_similarity.compareTwoStrings(wcString, pattern);
 			if (score > bestMatch.score) {
 				bestMatch.words = wc;

--- a/server/src/processing/KeyValueDetectionModule/defaultConfig.json
+++ b/server/src/processing/KeyValueDetectionModule/defaultConfig.json
@@ -1,15 +1,17 @@
 {
 	"name": "key-value-detection",
 	"description": "Detect pairs of key-value throughout each page of a document, depending on a certain number of key-value patterns passed onto the pipeline in the configuration.",
-	"keyPatterns": {
-		"value": {}
-	},
-	"keyValueDividerChars": [":", ";"],
-	"thresholdRatio": {
-		"value": 0.2,
-		"range": {
-			"min": 0.0,
-			"max": 1.0
+	"specs": {
+		"keyPatterns": {
+			"value": {}
+		},
+		"keyValueDividerChars": [":", ";"],
+		"thresholdRatio": {
+			"value": 0.2,
+			"range": {
+				"min": 0.0,
+				"max": 1.0
+			}
 		}
 	}
 }

--- a/server/src/processing/LinesToParagraphModule/LinesToParagraphModule.ts
+++ b/server/src/processing/LinesToParagraphModule/LinesToParagraphModule.ts
@@ -34,17 +34,8 @@ import { WordsToLineModule } from '../WordsToLineModule/WordsToLineModule';
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	tolerance?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-			step: number;
-		};
-	};
-	computeHeadings?: {
-		value: boolean;
-	};
+	tolerance?: number;
+	computeHeadings?: boolean;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -108,7 +99,7 @@ export class LinesToParagraphModule extends Module<Options> {
 				});
 			});
 
-			if (this.options.computeHeadings.value) {
+			if (this.options.computeHeadings) {
 				const newStructures = this.extractHeadings(joinedLines, textBodyFont);
 				const paras: Paragraph[] = this.mergeLinesIntoParagraphs(newStructures.newLines);
 				const headings: Heading[] = this.mergeLinesIntoHeadings(newStructures.headingLines);
@@ -163,7 +154,7 @@ export class LinesToParagraphModule extends Module<Options> {
 			const lines = this.getLinesInElement(element);
 			const interLinesSpaces = this.getInterLinesSpace(lines);
 			const joinedLines: Line[][] = this.joinLinesWithSpaces(lines, interLinesSpaces);
-			if (this.options.computeHeadings.value) {
+			if (this.options.computeHeadings) {
 				const newStructures = this.extractHeadings(joinedLines, textBodyFont);
 				const paras: Paragraph[] = this.mergeLinesIntoParagraphs(newStructures.newLines);
 				const headings: Heading[] = this.mergeLinesIntoHeadings(newStructures.headingLines);
@@ -317,7 +308,7 @@ export class LinesToParagraphModule extends Module<Options> {
 				index > 0 &&
 				distance.distanceHeightRatio.valueOf() -
 					sortedByDistance[index - 1].distanceHeightRatio.valueOf() <
-					this.options.tolerance.value
+					this.options.tolerance
 			) {
 				const mergedTotalHeight =
 					mergedDistances[mergedDistances.length - 1].totalHeight.valueOf() +

--- a/server/src/processing/LinesToParagraphModule/defaultConfig.json
+++ b/server/src/processing/LinesToParagraphModule/defaultConfig.json
@@ -1,16 +1,18 @@
 {
 	"name": "lines-to-paragraph",
 	"description": "Create paragraphs from a collection of lines.",
-	"tolerance": {
-		"value": 0.25,
-		"range": {
-			"min": 0.1,
-			"max": 1.0,
-			"step": 0.01
+	"specs": {
+		"tolerance": {
+			"value": 0.25,
+			"range": {
+				"min": 0.1,
+				"max": 1.0,
+				"step": 0.01
+			}
+		},
+		"computeHeadings": {
+			"value": true,
+			"range": [true, false]
 		}
-	},
-	"computeHeadings": {
-		"value": true,
-		"range": [true, false]
 	}
 }

--- a/server/src/processing/Module.ts
+++ b/server/src/processing/Module.ts
@@ -24,7 +24,19 @@ export class Module<T = undefined> {
 	private _extraOptions: any = {};
 
 	constructor(options?: T, defaultOptions?: T, extraOptions?: T) {
-		this._options = { ...defaultOptions, ...options };
+
+		/*
+			this takes the 'options' in key-value format and the 'defaultOptions' in specs format
+			and returns a merged object in key-value format, prioritizing the values in options object
+		*/
+		if (options && defaultOptions) {
+			const mergedOptions = (defaultOptions as any).specs;
+			Object.keys(mergedOptions).forEach(key => {
+				mergedOptions[key] = options[key] || mergedOptions[key].value;
+			});
+
+			this._options = mergedOptions;
+		}
 		this._extraOptions = extraOptions;
 	}
 

--- a/server/src/processing/Module.ts
+++ b/server/src/processing/Module.ts
@@ -29,10 +29,11 @@ export class Module<T = undefined> {
 			this takes the 'options' in key-value format and the 'defaultOptions' in specs format
 			and returns a merged object in key-value format, prioritizing the values in options object
 		*/
-		if (options && defaultOptions) {
-			const mergedOptions = (defaultOptions as any).specs;
+		this._options = {};
+		if (defaultOptions && defaultOptions.hasOwnProperty('specs')) {
+			const mergedOptions = Object.assign({}, (defaultOptions as any).specs);
 			Object.keys(mergedOptions).forEach(key => {
-				mergedOptions[key] = options[key] || mergedOptions[key].value;
+				mergedOptions[key] = (options && options[key]) || mergedOptions[key].value;
 			});
 
 			this._options = mergedOptions;

--- a/server/src/processing/NumberCorrectionModule/NumberCorrectionModule.ts
+++ b/server/src/processing/NumberCorrectionModule/NumberCorrectionModule.ts
@@ -32,22 +32,10 @@ import * as defaultConfig from './defaultConfig.json';
  */
 
 interface Options {
-	numberRegExp?: {
-		value: string;
-	};
-	fixSplitNumbers?: {
-		value: boolean;
-	};
-	maxConsecutiveSplits?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
-	whitelist?: {
-		value: string[];
-	};
+	numberRegExp?: string;
+	fixSplitNumbers?: boolean;
+	maxConsecutiveSplits?: number;
+	whitelist?: string[];
 }
 
 // The default regexps might be changed depending of the language and number notation.
@@ -77,7 +65,7 @@ export class NumberCorrectionModule extends Module<Options> {
 			// Correct numbers embedded into Words
 			this.correctWords(page);
 			// Correct numbers that might be split by mistake into exactly 2 Words under a Line node.
-			if (options.fixSplitNumbers.value) {
+			if (options.fixSplitNumbers) {
 				this.correctLines(page);
 			}
 		});
@@ -204,8 +192,8 @@ export class NumberCorrectionModule extends Module<Options> {
 	private getBestSuggestion(input: string, preCandidates?: Map<string, number>): string | null {
 		const suggestions = this.suggestNumberCorrections(
 			input,
-			RegExp(this.options.numberRegExp.value),
-			new Set(this.options.whitelist.value),
+			RegExp(this.options.numberRegExp),
+			new Set(this.options.whitelist),
 			preCandidates,
 		);
 		if (suggestions.length > 0) {
@@ -242,7 +230,7 @@ export class NumberCorrectionModule extends Module<Options> {
 			if (
 				line.content &&
 				line.content.length >= 2 &&
-				line.content.length <= this.options.maxConsecutiveSplits.value
+				line.content.length <= this.options.maxConsecutiveSplits
 			) {
 				// Make sure words are numbers
 				const consecutiveWordsAreNumbers = line.content.reduce((acc, word) => {

--- a/server/src/processing/NumberCorrectionModule/NumberCorrectionModule.ts
+++ b/server/src/processing/NumberCorrectionModule/NumberCorrectionModule.ts
@@ -60,12 +60,12 @@ export class NumberCorrectionModule extends Module<Options> {
 	}
 
 	public main(doc: Document): Document {
-		const options = Object.assign(defaultOptions, this.options);
+		// const options = Object.assign(defaultOptions, this.options);
 		doc.pages.forEach(page => {
 			// Correct numbers embedded into Words
 			this.correctWords(page);
 			// Correct numbers that might be split by mistake into exactly 2 Words under a Line node.
-			if (options.fixSplitNumbers) {
+			if (this.options.fixSplitNumbers) {
 				this.correctLines(page);
 			}
 		});

--- a/server/src/processing/NumberCorrectionModule/defaultConfig.json
+++ b/server/src/processing/NumberCorrectionModule/defaultConfig.json
@@ -1,21 +1,23 @@
 {
 	"name": "number-correction",
 	"description": "Perform error detection and correction on financial numbers.",
-	"fixSplitNumbers": {
-		"value": true,
-		"range": [true, false]
-	},
-	"maxConsecutiveSplits": {
-		"value": 3,
-		"range": {
-			"min": 0,
-			"max": 100
+	"specs": {
+		"fixSplitNumbers": {
+			"value": true,
+			"range": [true, false]
+		},
+		"maxConsecutiveSplits": {
+			"value": 3,
+			"range": {
+				"min": 0,
+				"max": 100
+			}
+		},
+		"numberRegExp": {
+			"value": "^([0-9]{1,3},([0-9]{3},)*[0-9]{3}|[0-9]+)(\\.[0-9]{2})?$"
+		},
+		"whitelist": {
+			"value": []
 		}
-	},
-	"numberRegExp": {
-		"value": "^([0-9]{1,3},([0-9]{3},)*[0-9]{3}|[0-9]+)(\\.[0-9]{2})?$"
-	},
-	"whitelist": {
-		"value": []
 	}
 }

--- a/server/src/processing/PageNumberDetectionModule/PageNumberDetectionModule.ts
+++ b/server/src/processing/PageNumberDetectionModule/PageNumberDetectionModule.ts
@@ -27,16 +27,8 @@ import { Module } from '../Module';
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	ignorePages?: {
-		value: number[];
-	};
-	maxMarginPercentage?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
+	ignorePages?: number[];
+	maxMarginPercentage?: number;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -63,7 +55,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 					'the document only has 1 page (not enough data).',
 			);
 			return doc;
-		} else if (this.options.maxMarginPercentage.value === undefined) {
+		} else if (this.options.maxMarginPercentage === undefined) {
 			logger.info(
 				'Not computing marginals (headers and footers); maxMarginPercentage setting not found in the configuration.',
 			);
@@ -76,7 +68,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 		}
 		logger.info(
 			'Detecting marginals (headers and footers) with maxMarginPercentage:',
-			this.options.maxMarginPercentage.value,
+			this.options.maxMarginPercentage,
 			'...',
 		);
 
@@ -92,7 +84,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 		}
 
 		doc.pages
-			.filter(p => !this.options.ignorePages.value.includes(p))
+			.filter(p => !this.options.ignorePages.includes(p))
 			.forEach(page => {
 				const h: number[] = page.horizontalOccupancy.map(boolToInt);
 				occupancyAcrossHeight = utils.addVectors(occupancyAcrossHeight, h);
@@ -116,7 +108,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 			});
 
 		const maxT: number = Math.floor(
-			0 + (this.options.maxMarginPercentage.value * occupancyAcrossHeight.length) / 100,
+			0 + (this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
 		);
 		doc.margins.top = heightZeros
 			.filter(value => value < maxT)
@@ -125,7 +117,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 			})[0];
 		const maxB: number = Math.floor(
 			occupancyAcrossHeight.length -
-				(this.options.maxMarginPercentage.value * occupancyAcrossHeight.length) / 100,
+				(this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
 		);
 		doc.margins.bottom = heightZeros
 			.filter(value => value > maxB)
@@ -133,7 +125,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 				return a - b;
 			})[0];
 		const maxL: number = Math.floor(
-			0 + (this.options.maxMarginPercentage.value * occupancyAcrossWidth.length) / 100,
+			0 + (this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
 		);
 		doc.margins.left = widthZeros
 			.filter(value => value < maxL)
@@ -142,7 +134,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 			})[0];
 		const maxR: number = Math.floor(
 			occupancyAcrossWidth.length -
-				(this.options.maxMarginPercentage.value * occupancyAcrossWidth.length) / 100,
+				(this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
 		);
 		doc.margins.right = widthZeros
 			.filter(value => value > maxR)
@@ -151,7 +143,7 @@ export class PageNumberDetectionModule extends Module<Options> {
 			})[0];
 
 		logger.info(
-			`Document margins for maxMarginPercentage ${this.options.maxMarginPercentage.value}: ` +
+			`Document margins for maxMarginPercentage ${this.options.maxMarginPercentage}: ` +
 				`top: ${doc.margins.top}, bottom: ${doc.margins.bottom}, ` +
 				`left: ${doc.margins.left}, right: ${doc.margins.right}`,
 		);

--- a/server/src/processing/PageNumberDetectionModule/defaultConfig.json
+++ b/server/src/processing/PageNumberDetectionModule/defaultConfig.json
@@ -1,14 +1,16 @@
 {
 	"name": "page-number-detection",
 	"description": "Detects the page number for each page in a document",
-	"ignorePages": {
-		"value": []
-	},
-	"maxMarginPercentage": {
-		"value": 30,
-		"range": {
-			"min": 0,
-			"max": 100
+	"specs": {
+		"ignorePages": {
+			"value": []
+		},
+		"maxMarginPercentage": {
+			"value": 30,
+			"range": {
+				"min": 0,
+				"max": 100
+			}
 		}
 	}
 }

--- a/server/src/processing/ReadingOrderDetectionModule/ReadingOrderDetectionModule.ts
+++ b/server/src/processing/ReadingOrderDetectionModule/ReadingOrderDetectionModule.ts
@@ -28,20 +28,8 @@ import * as defaultConfig from './defaultConfig.json';
  */
 
 interface Options {
-	minColumnWidthInPagePercent?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
-	minVerticalGapWidth?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
+	minColumnWidthInPagePercent?: number;
+	minVerticalGapWidth?: number;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -65,7 +53,7 @@ export class ReadingOrderDetectionModule extends Module<Options> {
 			this.order = 0;
 			// The min width is actually as a % of page width
 			this.currentPageMinColumnWidth = Math.trunc(
-				(this.options.minColumnWidthInPagePercent.value / 100) * page.width,
+				(this.options.minColumnWidthInPagePercent / 100) * page.width,
 			);
 
 			this.process(elements);
@@ -223,7 +211,7 @@ export class ReadingOrderDetectionModule extends Module<Options> {
 
 				elementsRest.forEach(e => {
 					if (
-						e.left <= rightmost + this.options.minVerticalGapWidth.value &&
+						e.left <= rightmost + this.options.minVerticalGapWidth &&
 						e.left >= startGroup &&
 						!group.includes(e)
 					) {

--- a/server/src/processing/ReadingOrderDetectionModule/defaultConfig.json
+++ b/server/src/processing/ReadingOrderDetectionModule/defaultConfig.json
@@ -1,18 +1,20 @@
 {
 	"name": "reading-order-detection",
 	"description": "Detect the reading order of the text items in the document.",
-	"minVerticalGapWidth": {
-		"value": 5,
-		"range": {
-			"min": 0,
-			"max": 100
-		}
-	},
-	"minColumnWidthInPagePercent": {
-		"value": 5,
-		"range": {
-			"min": 0,
-			"max": 100
+	"specs": {
+		"minVerticalGapWidth": {
+			"value": 5,
+			"range": {
+				"min": 0,
+				"max": 100
+			}
+		},
+		"minColumnWidthInPagePercent": {
+			"value": 5,
+			"range": {
+				"min": 0,
+				"max": 100
+			}
 		}
 	}
 }

--- a/server/src/processing/RedundancyDetectionModule/RedundancyDetectionModule.ts
+++ b/server/src/processing/RedundancyDetectionModule/RedundancyDetectionModule.ts
@@ -20,16 +20,7 @@ import { Module } from '../Module';
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	minOverlap?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
-	minimumPages?: {
-		value: number;
-	};
+	minOverlap?: number;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -105,7 +96,7 @@ export class RedundancyDetectionModule extends Module<Options> {
 			} else {
 				for (const e of group) {
 					const overlap: number = BoundingBox.getOverlap(e.box, newElement.box);
-					if (!(overlap >= this.options.minOverlap.value)) {
+					if (!(overlap >= this.options.minOverlap)) {
 						decision = false;
 						break;
 					}

--- a/server/src/processing/RedundancyDetectionModule/defaultConfig.json
+++ b/server/src/processing/RedundancyDetectionModule/defaultConfig.json
@@ -1,14 +1,14 @@
 {
 	"name": "redundancy-detection",
 	"description": "Detects and remove duplicate textual elements on each page of the document.",
-	"minOverlap": {
-		"value": 0.5,
-		"range": {
-			"min": 0.1,
-			"max": 1.0
+	"specs": {
+		"minOverlap": {
+			"value": 0.5,
+			"range": {
+				"min": 0.1,
+				"max": 1.0,
+				"step": 0.1
+			}
 		}
-	},
-	"minimumPages": {
-		"value": 6
 	}
 }

--- a/server/src/processing/RegexMatcherModule/RegexMatcherModule.ts
+++ b/server/src/processing/RegexMatcherModule/RegexMatcherModule.ts
@@ -22,15 +22,9 @@ import { Module } from '../Module';
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	queries?: {
-		value: Array<{ regex: string; label: string }>;
-	};
-	isGlobal?: {
-		value: boolean;
-	};
-	isCaseSensitive?: {
-		value: boolean;
-	};
+	queries?: Array<{ regex: string; label: string }>;
+	isGlobal?: boolean;
+	isCaseSensitive?: boolean;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -44,14 +38,14 @@ export class RegexMatcherModule extends Module<Options> {
 	}
 
 	public main(doc: Document): Document {
-		this.options.queries.value.forEach(query => {
+		this.options.queries.forEach(query => {
 			logger.info(`Labeling Texts with label ${query.label} from regex ${query.regex}`);
 
 			let regexType: string = '';
-			if (this.options.isGlobal.value) {
+			if (this.options.isGlobal) {
 				regexType += 'g';
 			}
-			if (this.options.isCaseSensitive.value) {
+			if (this.options.isCaseSensitive) {
 				regexType += 'i';
 			}
 

--- a/server/src/processing/RegexMatcherModule/defaultConfig.json
+++ b/server/src/processing/RegexMatcherModule/defaultConfig.json
@@ -1,15 +1,17 @@
 {
 	"name": "regex-matcher",
 	"description": "Matches the text against a certain number of Regular Expressions, configurable in the configuration.",
-	"isCaseSensitive": {
-		"value": true,
-		"range": [true, false]
-	},
-	"isGlobal": {
-		"value": true,
-		"range": [true, false]
-	},
-	"queries": {
-		"value": []
+	"specs": {
+		"isCaseSensitive": {
+			"value": true,
+			"range": [true, false]
+		},
+		"isGlobal": {
+			"value": true,
+			"range": [true, false]
+		},
+		"queries": {
+			"value": []
+		}
 	}
 }

--- a/server/src/processing/RemoteModule/RemoteModule.ts
+++ b/server/src/processing/RemoteModule/RemoteModule.ts
@@ -22,13 +22,8 @@ import { Module } from '../Module';
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	url?: {
-		value: number;
-	};
-	granularity?: {
-		value: string;
-		range: string[];
-	};
+	url?: string;
+	granularity?: string;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -41,12 +36,12 @@ export class RemoteModule extends Module<Options> {
 	}
 
 	public main(doc: Document): Promise<Document> {
-		const jsonExporter = new JsonExporter(doc, this.options.granularity.value);
+		const jsonExporter = new JsonExporter(doc, this.options.granularity);
 		const json: JsonExport = jsonExporter.getJson();
 
 		return axios({
 			method: 'POST',
-			url: this.options.url.value,
+			url: this.options.url,
 			data: json,
 			timeout: 0x7ffffff,
 		}).then((response: AxiosResponse<JsonExport>) => {

--- a/server/src/processing/RemoteModule/defaultConfig.json
+++ b/server/src/processing/RemoteModule/defaultConfig.json
@@ -1,11 +1,13 @@
 {
 	"name": "remote",
 	"description": "It exports the document as [JSON](../json-output.md), call an API with it and expect a modified JSON back.",
-	"url": {
-		"value": "localhost"
-	},
-	"granularity": {
-		"value": "word",
-		"range": ["word", "character"]
+	"specs": {
+		"url": {
+			"value": "localhost"
+		},
+		"granularity": {
+			"value": "word",
+			"range": ["word", "character"]
+		}
 	}
 }

--- a/server/src/processing/TableDetectionModule/README.md
+++ b/server/src/processing/TableDetectionModule/README.md
@@ -24,12 +24,8 @@ Following is an example of the configuration of the table-detection module:
 [
 	"table-detection",
 	{
-		"pages": {
-			"value": [1, 2, 3]   // or [] for all pages
-		}
-		"flavor": {
-			"value": "lattice"
-		}
+		"pages": [1, 2, 3],   // or [] for all pages
+		"flavor": "lattice"
 	}
 ]
 ```

--- a/server/src/processing/TableDetectionModule/TableDetectionModule.ts
+++ b/server/src/processing/TableDetectionModule/TableDetectionModule.ts
@@ -14,13 +14,8 @@ import { Module } from '../Module';
 import * as defaultConfig from './defaultConfig.json';
 
 export interface Options {
-	pages?: {
-		value: number[];
-	};
-	flavor?: {
-		value: string;
-		range: string[];
-	};
+	pages?: number[];
+	flavor?: string;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -40,15 +35,15 @@ const defaultExtractor: TableExtractor = {
 		let pages: string = 'all';
 		let flavor: string = 'lattice';
 		const lineScale: string = '70';
-		if (options.pages.value.length !== 0) {
-			pages = options.pages.value.toString();
+		if (options.pages.length !== 0) {
+			pages = options.pages.toString();
 		}
-		if (!options.flavor.value.includes(options.flavor.value)) {
+		if (!options.flavor.includes(options.flavor)) {
 			logger.warn(
-				`table detection flavor asked for: ${options.flavor.value} is not a possibility. defaulting to 'lattice'`,
+				`table detection flavor asked for: ${options.flavor} is not a possibility. defaulting to 'lattice'`,
 			);
 		} else {
-			flavor = options.flavor.value;
+			flavor = options.flavor;
 		}
 
 		// find python executable name
@@ -100,14 +95,15 @@ export class TableDetectionModule extends Module<Options> {
 	}
 
 	public main(doc: Document): Document {
-		const options: Options = { ...defaultOptions, ...this.options };
+		// options is already merged in constructor!!!
+		// const options: Options = { ...defaultOptions, ...this.options };
 		if (doc.getElementsOfType<Table>(Table).length > 0) {
 			logger.warn(
 				'Warning: document already has tables extracted by the extractor. Not performing table detection.',
 			);
 			return doc;
 		}
-		const tableExtractor = this.extractor.readTables(doc.inputFile, options);
+		const tableExtractor = this.extractor.readTables(doc.inputFile, this.options);
 
 		if (tableExtractor.status !== 0) {
 			logger.error(tableExtractor.stderr);

--- a/server/src/processing/TableDetectionModule/defaultConfig.json
+++ b/server/src/processing/TableDetectionModule/defaultConfig.json
@@ -1,11 +1,13 @@
 {
 	"name": "table-detection",
 	"description": "Table extraction from the PDF file",
-	"pages": {
-		"value": []
-	},
-	"flavor": {
-		"value": "lattice",
-		"range": ["lattice", "stream"]
+	"specs": {
+		"pages": {
+			"value": []
+		},
+		"flavor": {
+			"value": "lattice",
+			"range": ["lattice", "stream"]
+		}
 	}
 }

--- a/server/src/processing/TemplateModule/TemplateModule.ts
+++ b/server/src/processing/TemplateModule/TemplateModule.ts
@@ -23,10 +23,7 @@ import * as defaultConfig from './defaultConfig.json';
 // List of every options you need.
 // Don't forget the question mark!
 interface Options {
-	yourOption?: {
-		value: string;
-		range: string[];
-	};
+	yourOption?: string;
 }
 
 // Default options if none have been set in the configuration file.

--- a/server/src/processing/TemplateModule/defaultConfig.json
+++ b/server/src/processing/TemplateModule/defaultConfig.json
@@ -1,8 +1,10 @@
 {
 	"name": "template",
 	"description": "A boilerplate template showing how a template can be made",
-	"yourOption": {
-		"value": "Your value",
-		"min": ["option1", "option2"]
+	"specs": {
+		"yourOption": {
+			"value": "Your value",
+			"range": ["option1", "option2"]
+		}
 	}
 }

--- a/server/src/processing/WhitespaceRemovalModule/WhitespaceRemovalModule.ts
+++ b/server/src/processing/WhitespaceRemovalModule/WhitespaceRemovalModule.ts
@@ -19,13 +19,7 @@ import { Module } from '../Module';
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	minWidth?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
+	minWidth?: number;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -46,7 +40,7 @@ export class WhitespaceRemovalModule extends Module<Options> {
 			page.elements = page.elements.filter(e => {
 				return (
 					!(e instanceof Text) ||
-					(e.width < this.options.minWidth.value ||
+					(e.width < this.options.minWidth ||
 						(!/^\s*$/.test(e.toString()) && !isOverlapping(e, page)))
 				);
 			});

--- a/server/src/processing/WhitespaceRemovalModule/defaultConfig.json
+++ b/server/src/processing/WhitespaceRemovalModule/defaultConfig.json
@@ -1,8 +1,10 @@
 {
 	"name": "whitespace-removal",
 	"description": "Removes textual elements containing only whitespace as content.",
-	"minWidth": {
-		"value": 0,
-		"range": { "min": 0, "max": 100 }
+	"specs": {
+		"minWidth": {
+			"value": 0,
+			"range": { "min": 0, "max": 100 }
+		}
 	}
 }

--- a/server/src/processing/WordsToLineModule/WordsToLineModule.ts
+++ b/server/src/processing/WordsToLineModule/WordsToLineModule.ts
@@ -29,32 +29,10 @@ import { ReadingOrderDetectionModule } from '../ReadingOrderDetectionModule/Read
 import * as defaultConfig from './defaultConfig.json';
 
 interface Options {
-	lineHeightUncertainty?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-			step: number;
-		};
-	};
-	topUncertainty?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-			step: number;
-		};
-	};
-	maximumSpaceBetweenWords?: {
-		value: number;
-		range: {
-			min: number;
-			max: number;
-		};
-	};
-	mergeTableElements?: {
-		value: number;
-	};
+	lineHeightUncertainty?: number;
+	topUncertainty?: number;
+	maximumSpaceBetweenWords?: number;
+	mergeTableElements?: number;
 }
 
 const defaultOptions = (defaultConfig as any) as Options;
@@ -163,14 +141,14 @@ export class WordsToLineModule extends Module<Options> {
 				const curr = words[j];
 
 				if (
-					Math.abs(prev.top - curr.top) <= prev.height * opt.topUncertainty.value &&
+					Math.abs(prev.top - curr.top) <= prev.height * opt.topUncertainty &&
 					Math.abs(prev.height - curr.height) <=
-						prev.height * (1 + opt.lineHeightUncertainty.value) &&
-					curr.left - (prev.left + prev.width) <= opt.maximumSpaceBetweenWords.value &&
+						prev.height * (1 + opt.lineHeightUncertainty) &&
+					curr.left - (prev.left + prev.width) <= opt.maximumSpaceBetweenWords &&
 					// FIXME element cannot be a Heading since it is a Word
 					// (prev instanceof Heading) === (curr instanceof Heading) &&
 					prev.properties.isPageNumber === curr.properties.isPageNumber
-					// TODO: handle table elements: (opt.mergeTableElements.value
+					// TODO: handle table elements: (opt.mergeTableElements
 					// || (!prev.metadata.tableElement && !curr.metadata.tableElement))
 				) {
 					mergeGroup.push(curr);

--- a/server/src/processing/WordsToLineModule/defaultConfig.json
+++ b/server/src/processing/WordsToLineModule/defaultConfig.json
@@ -1,20 +1,22 @@
 {
 	"name": "words-to-line",
 	"description": "Create lines from a bunch of words, according to the reading order.",
-	"lineHeightUncertainty": {
-		"value": 0.2,
-		"range": { "min": 0.0, "max": 1.0, "step": 0.1 }
-	},
-	"topUncertainty": {
-		"value": 0.4,
-		"range": { "min": 0.0, "max": 1.0, "step": 0.1 }
-	},
-	"maximumSpaceBetweenWords": {
-		"value": 100,
-		"range": { "min": 0, "max": 100 }
-	},
-	"mergeTableElements": {
-		"value": false,
-		"range": [true, false]
+	"specs": {
+		"lineHeightUncertainty": {
+			"value": 0.2,
+			"range": { "min": 0.0, "max": 1.0, "step": 0.1 }
+		},
+		"topUncertainty": {
+			"value": 0.4,
+			"range": { "min": 0.0, "max": 1.0, "step": 0.1 }
+		},
+		"maximumSpaceBetweenWords": {
+			"value": 100,
+			"range": { "min": 0, "max": 100 }
+		},
+		"mergeTableElements": {
+			"value": false,
+			"range": [true, false]
+		}
 	}
 }


### PR DESCRIPTION
This PR is to simplify the format in the defaultConfig file, replacing the `"param": {"value": "foo"}` structure for `"param": "foo"`. 

Also changed the structure of each module's config file to a _specs format_:
```
{
  "name": "moduleName",
  "description": "moduleDescription",
  "specs": {
    "param1": {
      "value": "foo",
      "range": ["foo", "bar"]
  }
```

the Vue UI uses the "specs" format to show the configuration and sends the same config as "key-value" format to the server.

The modules in the pipeline now uses the "key-value" format.