### PR TITLE
[PdfMiner] Skip using empty words

### DIFF
--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -210,10 +210,10 @@ function breakLineIntoWords(
 	pageHeight: number,
 	scalingFactor: number = 1,
 ): Word[] {
-	let notAllowedChars = ['\u200B']; //&#8203 Zero Width Space
+	const notAllowedChars = ['\u200B']; // &#8203 Zero Width Space
 	const words: Word[] = [];
 	const chars: Character[] = line.text
-		.filter(char => !notAllowedChars.includes(char._))
+		.filter(char => !notAllowedChars.includes(char._) && char._attr !== undefined)
 		.map(char => {
 			if (char._ === undefined) {
 				return undefined;


### PR DESCRIPTION
There are some cases "testReadingOrder.pdf" that pdfminer extracts empty words with no attributes that makes parsr to create worng words

- See <text> <text> in pdfminer extraction.
<img width="1187" alt="Screenshot 2019-10-22 at 15 11 23" src="https://user-images.githubusercontent.com/12429149/67294594-50659200-f4e6-11e9-89a7-5249428e6d8f.png">

- See wrong behaviour -> Three words 'A' 'X' 'A'
<img width="278" alt="Screenshot 2019-10-22 at 15 10 39" src="https://user-images.githubusercontent.com/12429149/67294596-50659200-f4e6-11e9-806c-bd985bfbb3e8.png">

- See fixed behaviour -> One word 'AXA'
<img width="245" alt="Screenshot 2019-10-22 at 15 09 19" src="https://user-images.githubusercontent.com/12429149/67294597-50659200-f4e6-11e9-91f4-6e65d1f127e1.png">


