### PR TITLE
Fixed wrong ImageMagick command 'convert' used in Windows environment

### DIFF
--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -256,6 +256,7 @@ function main(): void {
 	function pdfToImage(pdfPath: string): string {
 		const tifFilePath = pdfPath + '.tiff';
 		const ret = child_process.spawnSync(utils.getConvertPath(), [
+			'convert',
 			'-density',
 			'200x200',
 			'-compress',

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -81,20 +81,14 @@ export function replaceObject<T extends Element, U extends T>(
 
 // Handle Windows convert.exe conflict.
 export function getConvertPath(): string {
-	if (/^win/i.test(os.platform())) {
-		const where = spawnSync('where.exe', ['magick']);
-		let filepaths: string[] = where.stdout.toString().split(os.EOL);
-		filepaths = filepaths.filter(
-			filepath => !/System/.test(filepath) && filepath.trim().length > 0,
-		);
+	const where = spawnSync(getExecLocationCommandOnSystem(), ['magick']);
+	let filepaths: string[] = where.stdout.toString().split(os.EOL);
+	filepaths = filepaths.filter(filepath => !/System/.test(filepath) && filepath.trim().length > 0);
 
-		if (filepaths.length === 0) {
-			throw new Error('Cannot find ImageMagick convert tool. Are you sure it is installed?');
-		} else {
-			return filepaths[0];
-		}
+	if (filepaths.length === 0) {
+		throw new Error('Cannot find ImageMagick convert tool. Are you sure it is installed?');
 	} else {
-		return 'magick';
+		return filepaths[0];
 	}
 }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -82,7 +82,7 @@ export function replaceObject<T extends Element, U extends T>(
 // Handle Windows convert.exe conflict.
 export function getConvertPath(): string {
 	if (/^win/i.test(os.platform())) {
-		const where = spawnSync('where.exe', ['convert']);
+		const where = spawnSync('where.exe', ['magick']);
 		let filepaths: string[] = where.stdout.toString().split(os.EOL);
 		filepaths = filepaths.filter(
 			filepath => !/System/.test(filepath) && filepath.trim().length > 0,
@@ -94,7 +94,7 @@ export function getConvertPath(): string {
 			return filepaths[0];
 		}
 	} else {
-		return 'convert';
+		return 'magick';
 	}
 }
 


### PR DESCRIPTION
When image based pdf is uploaded we are using imagemagick convert tool to generate an image from each page in order to be used as tesseract input.

We were using wrong command 'convert' (that works on MacOs but not in Windows) instead of use 'magick convert' (see https://imagemagick.org/script/convert.php)