### PR TITLE
Fix test execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"test": "test"
 	},
 	"scripts": {
-		"test": "mocha -t 10000 -r ts-node/register **/*.spec.ts",
+		"test": "mocha -t 10000 -r ts-node/register test/**/*.spec.ts",
 		"copyAssets": "copyfiles -u 2 \"./server/assets/*\" \"./dist/assets/\"",
 		"build:ts": "npm run copyAssets && tsc --outDir ./dist",
 		"build:ts:watch": "npm run copyAssets && tsc -w --outDir ./dist",

--- a/server/src/input/extract-fonts.ts
+++ b/server/src/input/extract-fonts.ts
@@ -16,7 +16,6 @@
 
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as utils from '../utils';
 import logger from '../utils/Logger';
 
@@ -27,10 +26,8 @@ import logger from '../utils/Logger';
  */
 export function extractFonts(pdfInputFile: string): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
-		const mutoolPath = spawnSync(utils.getExecLocationCommandOnSystem(), ['mutool']).output.join(
-			'',
-		);
-		if (mutoolPath === '' || (/^win/i.test(os.platform()) && /no mutool in/.test(mutoolPath))) {
+		const mutoolPath = utils.getCommandLocationOnSystem('mutool');
+		if (!mutoolPath) {
 			logger.warn('MuPDF not installed !! Skip fonts extraction.');
 			resolve();
 		} else {

--- a/server/src/input/pdf2json/pdf2json.ts
+++ b/server/src/input/pdf2json/pdf2json.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { spawn, spawnSync } from 'child_process';
+import { spawn } from 'child_process';
 import * as fs from 'fs';
 import { XmlEntities } from 'html-entities';
-import * as os from 'os';
 import { BoundingBox, Document, Font, Page, Text, Word } from '../../types/DocumentRepresentation';
 import { Pdf2JsonFont } from '../../types/Pdf2JsonFont';
 import { Pdf2JsonPage } from '../../types/Pdf2JsonPage';
@@ -148,10 +147,8 @@ function findOrCreate(newFont: Font, fonts: Font[]): Font {
  */
 function repairPdf(filePath: string) {
 	return new Promise<string>(resolve => {
-		const mutoolPath = spawnSync(utils.getExecLocationCommandOnSystem(), ['mutool']).output.join(
-			'',
-		);
-		if (mutoolPath === '' || (/^win/i.test(os.platform()) && /no mutool in/.test(mutoolPath))) {
+		const mutoolPath = utils.getCommandLocationOnSystem('mutool');
+		if (!mutoolPath) {
 			logger.warn('MuPDF not installed !! Skip clean PDF.');
 			resolve(filePath);
 		} else {

--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -16,7 +16,6 @@
 
 import { spawn } from 'child_process';
 import * as fs from 'fs';
-import * as os from 'os';
 import { parseString } from 'xml2js';
 import {
 	BoundingBox,
@@ -45,10 +44,10 @@ export function execute(pdfInputFile: string): Promise<Document> {
 		return repairPdf(pdfInputFile).then(repairedPdf => {
 			const xmlOutputFile: string = utils.getTemporaryFile('.xml');
 			let pdf2txtLocation: string = utils.getCommandLocationOnSystem('pdf2txt.py');
-			if (pdf2txtLocation === '') {
+			if (!pdf2txtLocation) {
 				pdf2txtLocation = utils.getCommandLocationOnSystem('pdf2txt');
 			}
-			if (pdf2txtLocation === '') {
+			if (!pdf2txtLocation) {
 				logger.debug(
 					`Unable to find pdf2txt, the pdfminer executable on the system. Are you sure it is installed?`,
 				);
@@ -352,7 +351,7 @@ function ncolourToHex(color: string) {
 function repairPdf(filePath: string) {
 	return new Promise<string>(resolve => {
 		const mutoolPath = utils.getCommandLocationOnSystem('mutool');
-		if (mutoolPath === '' || (/^win/i.test(os.platform()) && /no mutool in/.test(mutoolPath))) {
+		if (!mutoolPath) {
 			logger.warn('MuPDF not installed !! Skip clean PDF.');
 			resolve(filePath);
 		} else {

--- a/server/src/processing/TableDetectionModule/TableDetectionModule.ts
+++ b/server/src/processing/TableDetectionModule/TableDetectionModule.ts
@@ -48,10 +48,10 @@ const defaultExtractor: TableExtractor = {
 
 		// find python executable name
 		let pythonLocation: string = utils.getCommandLocationOnSystem('python3');
-		if (pythonLocation === '') {
+		if (!pythonLocation) {
 			pythonLocation = utils.getCommandLocationOnSystem('python');
 		}
-		if (pythonLocation === '') {
+		if (!pythonLocation) {
 			return {
 				stdout: '',
 				stderr: 'Unable to find python on the system. Are you sure it is installed?',

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -82,8 +82,14 @@ export function replaceObject<T extends Element, U extends T>(
 // Handle Windows convert.exe conflict.
 export function getConvertPath(): string {
 	const where = spawnSync(getExecLocationCommandOnSystem(), ['magick']);
-	let filepaths: string[] = where.stdout.toString().split(os.EOL);
-	filepaths = filepaths.filter(filepath => !/System/.test(filepath) && filepath.trim().length > 0);
+	let filepaths: string[] = [];
+
+	if (where.status === 0) {
+		filepaths = where.stdout.toString().split(os.EOL);
+		filepaths = filepaths.filter(
+			filepath => !/System/.test(filepath) && filepath.trim().length > 0,
+		);
+	}
 
 	if (filepaths.length === 0) {
 		throw new Error('Cannot find ImageMagick convert tool. Are you sure it is installed?');
@@ -680,14 +686,8 @@ export function getExecLocationCommandOnSystem(): string {
  * @param executableName the name of the executable to be located
  */
 export function getCommandLocationOnSystem(executableName: string): string {
-	const res: string = spawnSync(getExecLocationCommandOnSystem(), [
-		executableName,
-	]).stdout.toString();
-	if (res.slice(res.length - 1, res.length) === '\n') {
-		return res.slice(0, res.length - 1);
-	} else {
-		return res;
-	}
+	const info = spawnSync(getExecLocationCommandOnSystem(), [executableName]);
+	return info.status === 0 ? info.stdout.toString().split(os.EOL)[0] : null;
 }
 
 /**


### PR DESCRIPTION
Two issues are covered here:

1. Running `mocha **/*.spec.ts` will run tests everywhere, including
   those in `node_modules`. The fix scopes it to `test/**/*.spec.ts`.

2. Shell invocations of `where` or `which` assume an english response.
   The fix takes into account the return code instead (fortunately, both
   commands happen to return the same status codes.)