### PR TITLE
[Tesseract] Fixes a type casting issue in Tesseract extraction

### DIFF
--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -105,9 +105,6 @@ export function execute(pdfInputFile: string): Promise<Document> {
 					try {
 						logger.debug(`Converting pdfminer's XML output to JS object..`);
 						parseXmlToObject(xml).then((obj: any) => {
-							logger.info(
-								`Pages contain data of the following type ${Object.keys(obj.pages.page[0])}`,
-							);
 							const pages: Page[] = [];
 							obj.pages.page.forEach(pageObj => pages.push(getPage(pageObj)));
 							resolveDocument(new Document(pages, pdfInputFile));

--- a/server/src/input/set-page-dimensions.ts
+++ b/server/src/input/set-page-dimensions.ts
@@ -32,8 +32,8 @@ export function setPageDimensions(doc: Document, inputFileName: string): Promise
 				page.width = dimensions[i].width;
 				page.height = dimensions[i].height;
 				// Remove weird false positive coming from Tesseract
-				page.elements = page.elements.filter(t => {
-					return t.height !== page.height || t.width !== page.width;
+				page.elements = page.elements.filter(elem => {
+					return elem.height !== page.height || elem.width !== page.width;
 				});
 			});
 

--- a/server/src/input/tesseract/tesseract2json.ts
+++ b/server/src/input/tesseract/tesseract2json.ts
@@ -134,9 +134,13 @@ export function execute(imageInputFile: string, config: Config): Promise<Documen
 					pages[elem.page_num - 1].elements.push(word);
 				});
 
-				logger.info('Assigning object...');
+				logger.debug(`Assigning a total of ${pages.length} pages to the document...`);
 				const doc: Document = new Document(pages);
-				logger.debug('Done');
+				logger.debug(
+					`The new document contains ${
+						doc.getElementsOfType(Word, false).length
+					} words at extraction.`,
+				);
 				resolve(doc);
 			} else {
 				reject(`tesseract return code is ${code}`);

--- a/server/src/input/tesseract/tesseract2json.ts
+++ b/server/src/input/tesseract/tesseract2json.ts
@@ -149,7 +149,7 @@ export function execute(imageInputFile: string, config: Config): Promise<Documen
 	});
 }
 
-function parseTsv(tsv: string): any[] {
+function parseTsv(tsv: string): TsvElement[] {
 	const lines: string[] = tsv.split(/\r?\n/).filter(line => line.length !== 0);
 
 	const headers: string[] = lines.shift().split('\t');
@@ -161,6 +161,6 @@ function parseTsv(tsv: string): any[] {
 			record[headers[i]] = field;
 		});
 
-		return record;
+		return new TsvElement(record);
 	});
 }

--- a/server/src/processing/OutOfPageRemovalModule/OutOfPageRemovalModule.ts
+++ b/server/src/processing/OutOfPageRemovalModule/OutOfPageRemovalModule.ts
@@ -29,7 +29,7 @@ export class OutOfPageRemovalModule extends Module {
 	public main(doc: Document): Document {
 		doc.pages.forEach((page: Page) => {
 			page.elements = page.elements.filter((element: Element) => {
-				return !(element instanceof Text) || utils.isInBox(element, page.box);
+				return !(element instanceof Text) || utils.isInBox(element, page.box, true);
 			});
 		});
 

--- a/server/src/types/TsvElement.ts
+++ b/server/src/types/TsvElement.ts
@@ -29,4 +29,19 @@ export class TsvElement {
 	public height: number;
 	public conf: number;
 	public text: string;
+
+	constructor(obj: any) {
+		this.level = parseFloat(obj.level);
+		this.page_num = parseFloat(obj.page_num);
+		this.block_num = parseFloat(obj.block_num);
+		this.par_num = parseFloat(obj.par_num);
+		this.line_num = parseFloat(obj.line_num);
+		this.word_num = parseFloat(obj.word_num);
+		this.left = parseFloat(obj.left);
+		this.top = parseFloat(obj.top);
+		this.width = parseFloat(obj.width);
+		this.height = parseFloat(obj.height);
+		this.conf = parseFloat(obj.conf);
+		this.text = obj.text.toString();
+	}
 }

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -299,12 +299,7 @@ export function isInBox(element: Element, box: BoundingBox, strict: boolean = tr
 			element.box.left + element.box.width <= box.left + box.width
 		);
 	} else {
-		return (
-			element.box.top < box.top + box.height &&
-			element.box.top + element.box.height > box.top &&
-			element.box.left < box.left + box.width &&
-			element.box.left + element.box.width > box.left
-		);
+		return BoundingBox.getOverlap(element.box, box) === 0;
 	}
 }
 


### PR DESCRIPTION
- Bounding boxes and other fields were not being casted as number based objects but strings instead, which caused the `OutOfPageModule` to remove almost all elements from the tesseract output.
- This PR fixes that issue.