### PR TITLE
Change email address in Swagger for opensource@axa.com

### DIFF
--- a/api/swagger/openapi.yaml
+++ b/api/swagger/openapi.yaml
@@ -4,7 +4,7 @@ info:
   version: '1.0.0'
   title: 'Parsr API'
   contact:
-    email: 'sacha.bron.ats@axa.com'
+    email: 'opensource@axa.com'
     name: Parsr
     url: https://github.com/axa-group/Parsr
 

--- a/api/swagger/swagger-generated.yaml
+++ b/api/swagger/swagger-generated.yaml
@@ -4,7 +4,7 @@ info:
   contact:
     name: Parsr
     url: https://github.com/axa-group/Parsr
-    email: sacha.bron.ats@axa.com
+    email: opensource@axa.com
   version: 1.0.0
 servers:
   - url: https://localhost:3000/api/v1

--- a/docs/api.html
+++ b/docs/api.html
@@ -3338,7 +3338,7 @@ except ApiException as e:
             <div id="api-_footer">
               <p>Suggestions, contact, support and error reporting;
                   <div class="app-desc">Information URL: <a href="https://github.com/axa-group/parsr">https://github.com/axa-group/parsr</a></div>
-                  <div class="app-desc">Contact Info: <a href="sacha.bron.ats@axa.com">sacha.bron.ats@axa.com</a></div>
+                  <div class="app-desc">Contact Info: <a href="opensource@axa.com">opensource@axa.com</a></div>
               </p>
                 <div class="license-info">All rights reserved</div>
                 <div class="license-url">http://apache.org/licenses/LICENSE-2.0.html</div>


### PR DESCRIPTION
We have a security requirement to change these email addresses.
I checked with them and we can have the official AXA open source email address instead. 