### PR TITLE
Redirect demo to /upload instead of empty Home. Change title to Parsr from vue-viewer.

### DIFF
--- a/demo/vue-viewer/public/index.html
+++ b/demo/vue-viewer/public/index.html
@@ -5,7 +5,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<link rel="icon" href="<%= BASE_URL %>favicon.ico" />
-		<title>vue-viewer</title>
+		<title>Parsr</title>
 		<link
 			rel="stylesheet"
 			href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900"

--- a/demo/vue-viewer/src/router.js
+++ b/demo/vue-viewer/src/router.js
@@ -15,8 +15,7 @@ export default new Router({
 	routes: [
 		{
 			path: '/',
-			name: 'home',
-			component: Home,
+			redirect: '/upload',
 		},
 		{
 			path: '/upload',
@@ -45,7 +44,7 @@ export default new Router({
 		},
 		{
 			path: '*',
-			redirect: { name: 'home' },
+			redirect: { name: 'upload' },
 		},
 	],
 });


### PR DESCRIPTION
Simple and small improvements on the Parsr Web Demo.