### PR TITLE
removing pdf2json from Docker image

### DIFF
--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -1,17 +1,3 @@
-FROM debian:10 as builder 
-
-RUN apt-get update && \ 
-    apt-get install -y git build-essential
-
-RUN git clone https://github.com/AXATechLab/pdf2json /src/pdf2json && \
-    cd /src/pdf2json && \
-    ./configure --prefix=/opt/pdf2json && \
-    make -j && \
-    make install && \
-    cd /src && \
-    rm -rf pdf2json
-
-
 FROM debian:10 as engine
 
 RUN apt-get update && \
@@ -21,8 +7,6 @@ RUN apt-get update && \
     
 WORKDIR /opt/app-root/src
 RUN chown 1001:0 /opt/app-root/src
-
-COPY --from=builder /opt/pdf2json /opt/pdf2json
 
 ENV PATH $PATH:/opt/app-root/src/node_modules/.bin:/opt/pdf2json/bin
 ENV HOME /opt/app-root/src

--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 WORKDIR /opt/app-root/src
 RUN chown 1001:0 /opt/app-root/src
 
-ENV PATH $PATH:/opt/app-root/src/node_modules/.bin:/opt/pdf2json/bin
+ENV PATH $PATH:/opt/app-root/src/node_modules/.bin
 ENV HOME /opt/app-root/src
 
 USER 1001


### PR DESCRIPTION
Following https://github.com/axa-group/Parsr/pull/168
Cleanup Docker image from pdf2json