### PR TITLE
Heading max markdown level 

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && npm test && npm audit",
+      "pre-commit": "npm run lint",
       "pre-push": "npm test && npm audit"
     }
   },

--- a/server/src/types/DocumentRepresentation/Heading.ts
+++ b/server/src/types/DocumentRepresentation/Heading.ts
@@ -57,7 +57,7 @@ export class Heading extends Paragraph {
    * Converts the entire paragraph into a string form with formatting, with spaces between words.
    */
   public toMarkdown(): string {
-    if (this.level === 0) {
+    if (this.level === 0 || this.level > 6) {
       return super.toMarkdown();
     }
     return '#'.repeat(this.level) + ' ' + this.toString();


### PR DESCRIPTION
Fixed md generation in Headings as max level supported by MD is 6

After
<img width="1425" alt="Screenshot 2019-10-31 at 12 49 03" src="https://user-images.githubusercontent.com/12429149/67944736-702f4100-fbdd-11e9-9d39-53870b99cb64.png">

Before
<img width="1437" alt="Screenshot 2019-10-31 at 12 50 09" src="https://user-images.githubusercontent.com/12429149/67944740-745b5e80-fbdd-11e9-980e-43ee9c4afa3f.png">
