### PR TITLE
Escape Markdown Numbers when not a List

### DIFF
--- a/server/src/types/DocumentRepresentation/Word.ts
+++ b/server/src/types/DocumentRepresentation/Word.ts
@@ -38,7 +38,15 @@ export class Word extends Text {
   }
 
   public toMarkDown(): string {
-    return this.properties.link ? this.properties.link : this.toString();
+    let mdString: string;
+
+    if (this.properties.link) {
+      mdString = this.properties.link;
+    } else {
+      mdString = this.toString().replace(/([\d]+)([\.\)])/g, '$1\\$2');
+    }
+
+    return mdString;
   }
 
   public toString(): string {


### PR DESCRIPTION
Add backslashes on dot and closing parentheses after numbers to comply to Markdown standards. 