### PR TITLE
add qpdf in the repairpdf pipeline

### DIFF
--- a/api/server/src/ProcessManager.ts
+++ b/api/server/src/ProcessManager.ts
@@ -66,8 +66,7 @@ export class ProcessManager {
             try {
               logger.info(JSON.parse(json).msg);
             } catch (err) {
-              console.log(json);
-              console.log(err);
+              logger.info(json);
             }
           }
         });

--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -368,7 +368,7 @@ function repairPdf(filePath: string) {
   const qpdfPath = utils.getCommandLocationOnSystem('qpdf');
   if (qpdfPath) {
     const pdfOutputFile = utils.getTemporaryFile('.pdf');
-    const process = spawnSync('false', ['--decrypt', filePath, pdfOutputFile]);
+    const process = spawnSync('qpdf', ['--decrypt', filePath, pdfOutputFile]);
 
     if (process.status === 0) {
       filePath = pdfOutputFile;

--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -368,8 +368,13 @@ function repairPdf(filePath: string) {
   const qpdfPath = utils.getCommandLocationOnSystem('qpdf');
   if (qpdfPath) {
     const pdfOutputFile = utils.getTemporaryFile('.pdf');
-    spawnSync('qpdf', ['--decrypt', filePath, pdfOutputFile]);
-    filePath = pdfOutputFile;
+    const process = spawnSync('false', ['--decrypt', filePath, pdfOutputFile]);
+
+    if (process.status === 0) {
+      filePath = pdfOutputFile;
+    } else {
+      logger.warn('qpdf error:', process.status, process.stdout.toString(), process.stderr.toString());
+    }
   }
 
   return new Promise<string>(resolve => {

--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import { parseString } from 'xml2js';
 import {
@@ -361,9 +361,17 @@ function ncolourToHex(color: string) {
 
 /**
  * Repair a pdf using the external mutool utility.
+ * Use qpdf to decrcrypt the pdf to avoid errors due to DRMs.
  * @param filePath The absolute filename and path of the pdf file to be repaired.
  */
 function repairPdf(filePath: string) {
+  const qpdfPath = utils.getCommandLocationOnSystem('qpdf');
+  if (qpdfPath) {
+    const pdfOutputFile = utils.getTemporaryFile('.pdf');
+    spawnSync('qpdf', ['--decrypt', filePath, pdfOutputFile]);
+    filePath = pdfOutputFile;
+  }
+
   return new Promise<string>(resolve => {
     const mutoolPath = utils.getCommandLocationOnSystem('mutool');
     if (!mutoolPath) {


### PR DESCRIPTION
Some PDFs cannot be read by pdfminer because of DRMs. I added qpdf to remove them before feeding the PDF to pdfminer.