### PR TITLE
Heading Fixes

### DIFF
--- a/server/src/processing/LinesToParagraphModule/LinesToParagraphModule.ts
+++ b/server/src/processing/LinesToParagraphModule/LinesToParagraphModule.ts
@@ -458,14 +458,16 @@ export class LinesToParagraphModule extends Module<Options> {
               newLineGroups.push(newLines);
             }
           });
-          utils.groupConsecutiveNumbersInArray(headingIdx).forEach((group: number[]) => {
-            const newHeadings: Line[] = [];
-            group.forEach((id: number) => {
-              newHeadings.push(lineGroup[id]);
+          this.groupHeadingsByFont(headingIdx, lineGroup).forEach(headingGroup => {
+            utils.groupConsecutiveNumbersInArray(headingGroup).forEach((group: number[]) => {
+              const newHeadings: Line[] = [];
+              group.forEach((id: number) => {
+                newHeadings.push(lineGroup[id]);
+              });
+              if (newHeadings.length > 0) {
+                newHeadingGroups.push(newHeadings);
+              }
             });
-            if (newHeadings.length > 0) {
-              newHeadingGroups.push(newHeadings);
-            }
           });
         } else {
           newLineGroups.push(lineGroup);
@@ -517,5 +519,26 @@ export class LinesToParagraphModule extends Module<Options> {
         .indexOf(serializeFont(h));
       h.level = level + 1;
     });
+  }
+
+  private groupHeadingsByFont(headingIndexes: number[], lines: Line[]): number[][] {
+    // Skip join heading lines if they doesn't have same font
+    const fontGroupedHeadings: number[][] = [];
+    let joinedHeadings: number[] = [];
+    headingIndexes.forEach((pos, index) => {
+      const currentHeadingLineFont = lines[pos].getMainFont();
+      const prevHeadingLineFont = index > 0 ? lines[index - 1].getMainFont() : null;
+      if (!prevHeadingLineFont || currentHeadingLineFont.isEqual(prevHeadingLineFont)) {
+        joinedHeadings.push(pos);
+      } else {
+        fontGroupedHeadings.push(joinedHeadings);
+        joinedHeadings = [pos];
+      }
+    });
+    if (joinedHeadings.length > 0) {
+      fontGroupedHeadings.push(joinedHeadings);
+    }
+
+    return fontGroupedHeadings;
   }
 }

--- a/test/paragraph-merge.spec.ts
+++ b/test/paragraph-merge.spec.ts
@@ -130,6 +130,6 @@ describe('Paragraph merge function with tables ans more', () => {
   it('should merge side-by-side lines into paragraphs', () => {
     expect(docAfter.pages[0].getElementsOfType<Paragraph>(Paragraph, true))
       .to.be.an('array')
-      .and.to.be.of.length(52);
+      .and.to.be.of.length(53);
   });
 });

--- a/test/unit/lines-to-paragraph.spec.ts
+++ b/test/unit/lines-to-paragraph.spec.ts
@@ -30,7 +30,7 @@ describe('Lines to Paragraph Module', () => {
       'one paragraph doc': ['one-paragraph-with-lines.json', 1],
       'multiple paragraphs': ['paragraph-merge.json', 4],
       'multicolumn paragraphs': ['paragraph-merge-2.json', 5],
-      'full content page': ['paragraph-merge-5.json', 10],
+      'full content page': ['paragraph-merge-5.json', 11],
     },
     (fileName, paragraphCount) => {
       let docBefore: Document;
@@ -70,7 +70,7 @@ describe('Heading Detection', () => {
   withData(
     {
       'multiple paragraphs with headings': ['paragraph-merge-3.json', 4],
-      'complex pdf file': ['testReadingOrder.json', 5],
+      'complex pdf file': ['testReadingOrder.json', 8],
     },
     (fileName, headingCount) => {
       before(done => {


### PR DESCRIPTION
Improve headings detection to fix some bugs.

Each line with same font in purple box has to be a heading (we expect to have 1 purple box for each line with same font)
- Before
<img width="225" alt="Headings_Bug_1a" src="https://user-images.githubusercontent.com/12429149/68212662-45c4f580-ffda-11e9-9a51-b909ff7b4714.png"><img width="200" alt="Headings_Bug_1" src="https://user-images.githubusercontent.com/12429149/68212664-465d8c00-ffda-11e9-9a9d-f7a7a1eb1ef7.png">

- After
<img width="225" alt="Headings_Bug_1a_Fixed" src="https://user-images.githubusercontent.com/12429149/68212661-45c4f580-ffda-11e9-9746-6fb0b306d6ce.png"><img width="200" alt="Headings_Bug_1_Fixed" src="https://user-images.githubusercontent.com/12429149/68212663-45c4f580-ffda-11e9-92e8-b6b162724569.png">


Test files: 
[Headings_Consecutives.pdf](https://github.com/axa-group/Parsr/files/3809218/Headings_Consecutives.pdf)
[Headings_Consecutives_single_lines.pdf](https://github.com/axa-group/Parsr/files/3809219/Headings_Consecutives_single_lines.pdf)
