### PR TITLE
[Issue #188] Correctly execute qpdf; store the repaired file's name on Doc

### DIFF
--- a/server/src/Orchestrator.ts
+++ b/server/src/Orchestrator.ts
@@ -52,8 +52,6 @@ export class Orchestrator {
     logger.info(`Using extractor: ${this.extractor.constructor.name}`);
 
     return this.extractor.run(filename).then((doc: Document) => {
-      doc.inputFile = filename;
-
       logger.info('Running cleaner...');
       return this.cleaner.run(doc);
     });

--- a/server/src/input/extract-fonts.ts
+++ b/server/src/input/extract-fonts.ts
@@ -28,13 +28,11 @@ export function extractFonts(pdfInputFile: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const mutoolPath = utils.getCommandLocationOnSystem('mutool');
     if (!mutoolPath) {
-      logger.warn('MuPDF not installed !! Skip fonts extraction.');
+      logger.warn('MuPDF not installed. Skipping fonts extraction...');
       resolve();
     } else {
       const folder = utils.getMutoolExtractionFolder();
-      logger.info(`Extracting fonts to ${folder}...`);
-      const command = `mutool extract '${pdfInputFile}'`;
-      logger.debug(command);
+      logger.info(`Extracting fonts to ${folder} using command 'mutool extract ${pdfInputFile}'...`);
       const ret = spawnSync('mutool', ['extract', pdfInputFile], { cwd: folder });
 
       if (ret.status !== 0) {

--- a/server/src/input/tesseract/tesseract2json.ts
+++ b/server/src/input/tesseract/tesseract2json.ts
@@ -135,7 +135,7 @@ export function execute(imageInputFile: string, config: Config): Promise<Documen
         });
 
         logger.debug(`Assigning a total of ${pages.length} pages to the document...`);
-        const doc: Document = new Document(pages);
+        const doc: Document = new Document(pages, imageInputFile);
         logger.debug(
           `The new document contains ${
             doc.getElementsOfType(Word, false).length

--- a/server/src/processing/TableDetectionModule/TableDetectionModule.ts
+++ b/server/src/processing/TableDetectionModule/TableDetectionModule.ts
@@ -112,6 +112,23 @@ export class TableDetectionModule extends Module<Options> {
       );
       return doc;
     }
+
+    try {
+      if (fs.existsSync(doc.inputFile)) {
+        logger.info(
+          `Attempting table detection on ${doc.inputFile}..`,
+        );
+      } else {
+        logger.warn(
+          `Warning: The configured input filename ${doc.inputFile} cannot be found. Not performing table detection.`,
+        );
+        return doc;
+      }
+    } catch (err) {
+      logger.error(`Could not check if the input file ${doc.inputFile} exists: ${err}..`);
+      return doc;
+    }
+
     const tableExtractor = this.extractor.readTables(doc.inputFile, this.options);
 
     if (tableExtractor.status !== 0) {


### PR DESCRIPTION
1. Proper chain qpdf -> mutool -> extraction
2. Store the correct repaired filename in the Document object
3. Make sure the `TableDetectionModule` executes on the repaired file