### PR TITLE
[pdfminer] Patch - Let figures contain text elements too

### DIFF
--- a/server/src/types/PdfminerFigure.ts
+++ b/server/src/types/PdfminerFigure.ts
@@ -15,6 +15,7 @@
  */
 
 import { PdfminerImage } from './PdfminerImage';
+import { PdfminerText } from './PdfminerText';
 
 export class PdfminerFigure {
   public _attr: {
@@ -22,9 +23,11 @@ export class PdfminerFigure {
     bbox: string;
   };
   public image: PdfminerImage[];
+  public text: PdfminerText[];
 
-  constructor(textbox: PdfminerFigure) {
-    this._attr = textbox._attr;
-    this.image = textbox.image;
+  constructor(figure: PdfminerFigure) {
+    this._attr = figure._attr;
+    this.image = figure.image;
+    this.text = figure.text;
   }
 }


### PR DESCRIPTION
Currently the figure elements only contained images, but apparently the
figure elements can also contain text.
This makes required changes for this flexibility to be available.