### PR TITLE
[TableDetection] - modified TableDetectionModule configuration options

### DIFF
--- a/server/assets/TableDetectionScript.py
+++ b/server/assets/TableDetectionScript.py
@@ -138,7 +138,10 @@ def main():
     if len(sys.argv) > 4:
         pages = str(sys.argv[4])
 
-    tables = camelot.read_pdf(pdfFile,  pages=pages, flavor=flavor, line_scale=lineScale)
+    if flavor == 'lattice':
+        tables = camelot.read_pdf(pdfFile,  pages=pages, flavor=flavor, line_scale=lineScale)
+    else: 
+        tables = camelot.read_pdf(pdfFile,  pages=pages, flavor=flavor)
 
     if len(tables) == 0:
         #print('No tables detected ', tables)

--- a/server/defaultConfig.json
+++ b/server/defaultConfig.json
@@ -22,8 +22,12 @@
     [
       "table-detection",
       {
-        "pages": [],
-        "flavor": "lattice"
+        "pageConfig": [
+          {
+            "pages": [],
+            "flavor": "lattice"
+          }
+        ]
       }
     ],
     [

--- a/server/src/processing/TableDetectionModule/README.md
+++ b/server/src/processing/TableDetectionModule/README.md
@@ -24,14 +24,19 @@ Following is an example of the configuration of the table-detection module:
 [
   "table-detection",
   {
-    "pages": [1, 2, 3], // or [] for all pages
-    "flavor": "lattice"
+        "pageConfig": [
+          {
+            "pages": [1, 2, 3], // or [] for all pages
+            "flavor": "lattice"
+          }
+        ]
   }
 ]
 ```
 
-- pages: List of numbers representing pages.
-- flavor: The parsing method to use ('lattice' or 'stream'). Lattice is used by default.
+- pageConfig: Array of different configurations for the doc
+  - pages: List of numbers representing pages.
+  - flavor: The parsing method to use ('lattice' or 'stream'). Lattice is used by default.
 
 ## Accuracy
 
@@ -40,4 +45,3 @@ The accuracy is high.
 ## Limitations
 
 - Only works with text-based PDFs and not scanned documents.
-- Currently we can not configure this module to use a specific configuration for each page.

--- a/server/src/processing/TableDetectionModule/TableDetectionModule.ts
+++ b/server/src/processing/TableDetectionModule/TableDetectionModule.ts
@@ -97,8 +97,6 @@ export class TableDetectionModule extends Module<Options> {
   }
 
   public main(doc: Document): Document {
-    // options is already merged in constructor!!!
-    // const options: Options = { ...defaultOptions, ...this.options };
     const fileType: { ext: string; mime: string } = filetype(fs.readFileSync(doc.inputFile));
     if (fileType === null || fileType.ext !== 'pdf') {
       logger.warn(
@@ -129,15 +127,16 @@ export class TableDetectionModule extends Module<Options> {
       return doc;
     }
 
-    const tableExtractor = this.extractor.readTables(doc.inputFile, this.options);
-
-    if (tableExtractor.status !== 0) {
-      logger.error(tableExtractor.stderr);
-    } else {
-      const tablesData = JSON.parse(tableExtractor.stdout);
-      this.addTables(tablesData, doc);
-      this.removeWordsUsedInCells(doc);
-    }
+    this.options.pageConfig.forEach(config => {
+      const tableExtractor = this.extractor.readTables(doc.inputFile, config);
+      if (tableExtractor.status !== 0) {
+        logger.error(tableExtractor.stderr);
+      } else {
+        const tablesData = JSON.parse(tableExtractor.stdout);
+        this.addTables(tablesData, doc);
+        this.removeWordsUsedInCells(doc);
+      }
+    });
     return doc;
   }
 

--- a/server/src/processing/TableDetectionModule/defaultConfig.json
+++ b/server/src/processing/TableDetectionModule/defaultConfig.json
@@ -1,13 +1,14 @@
 {
-	"name": "table-detection",
-	"description": "Table extraction from the PDF file",
-	"specs": {
-		"pages": {
-			"value": []
-		},
-		"flavor": {
-			"value": "lattice",
-			"range": ["lattice", "stream"]
-		}
-	}
+  "name": "table-detection",
+  "description": "Table extraction from the PDF file",
+  "specs": {
+    "pageConfig": {
+      "value": [
+        {
+          "pages": [],
+          "flavor": "lattice"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
This will allows the user to execute multiple camelot runs on the document, using different customized options to increase accuracy on table detection.

It's the first step on solving this clubhouse story:
https://app.clubhouse.io/parsr/story/3031/tables-aren-t-detected-in-this-pdf

**TODO**: find a better name for the `pageConfig` option 🤔 