### PR TITLE
[pdfminer] Call pdfminer with the python interpreter

### DIFF
--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -79,9 +79,9 @@ export function execute(pdfInputFile: string): Promise<Document> {
         fs.appendFileSync(xmlOutputFile, '');
       }
 
-      const pdfminer = spawn(pythonLocation, pdf2txtArguments);
+      const pdf2txt = spawn(pythonLocation, pdf2txtArguments);
 
-      pdfminer.stderr.on('data', data => {
+      pdf2txt.stderr.on('data', data => {
         logger.error('pdfminer error:', data.toString('utf8'));
       });
 
@@ -97,8 +97,8 @@ export function execute(pdfInputFile: string): Promise<Document> {
         return promise;
       }
 
-      pdfminer.on('close', async code => {
-        if (code === 0) {
+      pdf2txt.on('close', pdf2txtReturnCode => {
+        if (pdf2txtReturnCode === 0) {
           const xml: string = fs.readFileSync(xmlOutputFile, 'utf8');
           try {
             logger.debug(`Converting pdfminer's XML output to JS object..`);
@@ -111,7 +111,7 @@ export function execute(pdfInputFile: string): Promise<Document> {
             rejectDocument(`parseXml failed: ${err}`);
           }
         } else {
-          rejectDocument(`pdfminer return code is ${code}`);
+          rejectDocument(`pdf2txt return code is ${pdf2txtReturnCode}`);
         }
       });
       // return doc;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -121,12 +121,28 @@ export function getPdf2txtLocation(): string {
   const pdf2txtLocation: string = getCommandLocationOnSystem('pdf2txt.py', 'pdf2txt');
   if (!pdf2txtLocation) {
     logger.warn(
-      `Unable to find pdf2txt, the pdfminer executable on the system. Are you sure it is installed?`,
+      `Unable to find pdf2txt, the pdfminer tool on the system. Are you sure it is installed?`,
     );
     return "";
   } else {
     logger.debug(`pdf2txt was found at ${pdf2txtLocation}`);
     return pdf2txtLocation;
+  }
+}
+
+/**
+ * Returns the location of the dumppdf command on the system
+ */
+export function getDumppdfLocation(): string {
+  const dumppdfLocation: string = getCommandLocationOnSystem('dumppdf.py', 'dumppdf');
+  if (!dumppdfLocation) {
+    logger.warn(
+      `Unable to find dump, the pdfminer tool on the system. Are you sure it is installed?`,
+    );
+    return "";
+  } else {
+    logger.debug(`dumppdf was found at ${dumppdfLocation}`);
+    return dumppdfLocation;
   }
 }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -98,6 +98,44 @@ export function getConvertPath(): string {
   }
 }
 
+/**
+ * Returns the location of the python command on the system
+ */
+export function getPythonLocation(): string {
+  let pythonLocation: string = getCommandLocationOnSystem('python3');
+  if (!pythonLocation) {
+    pythonLocation = getCommandLocationOnSystem('python');
+  }
+  if (!pythonLocation) {
+    logger.warn(
+      `Unable to find python. Are you sure it is installed?`,
+    );
+    return "";
+  } else {
+    logger.debug(`python was found at ${pythonLocation}`);
+    return pythonLocation;
+  }
+}
+
+/**
+ * Returns the location of the pdf2txt command on the system
+ */
+export function getPdf2txtLocation(): string {
+  let pdf2txtLocation: string = getCommandLocationOnSystem('pdf2txt.py');
+  if (!pdf2txtLocation) {
+    pdf2txtLocation = getCommandLocationOnSystem('pdf2txt');
+  }
+  if (!pdf2txtLocation) {
+    logger.warn(
+      `Unable to find pdf2txt, the pdfminer executable on the system. Are you sure it is installed?`,
+    );
+    return "";
+  } else {
+    logger.debug(`pdf2txt was found at ${pdf2txtLocation}`);
+    return pdf2txtLocation;
+  }
+}
+
 export function getMutoolImagesPrefix(): string {
   return 'page';
 }

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -102,10 +102,7 @@ export function getConvertPath(): string {
  * Returns the location of the python command on the system
  */
 export function getPythonLocation(): string {
-  let pythonLocation: string = getCommandLocationOnSystem('python3');
-  if (!pythonLocation) {
-    pythonLocation = getCommandLocationOnSystem('python');
-  }
+  const pythonLocation: string = getCommandLocationOnSystem('python3', 'python');
   if (!pythonLocation) {
     logger.warn(
       `Unable to find python. Are you sure it is installed?`,
@@ -121,10 +118,7 @@ export function getPythonLocation(): string {
  * Returns the location of the pdf2txt command on the system
  */
 export function getPdf2txtLocation(): string {
-  let pdf2txtLocation: string = getCommandLocationOnSystem('pdf2txt.py');
-  if (!pdf2txtLocation) {
-    pdf2txtLocation = getCommandLocationOnSystem('pdf2txt');
-  }
+  const pdf2txtLocation: string = getCommandLocationOnSystem('pdf2txt.py', 'pdf2txt');
   if (!pdf2txtLocation) {
     logger.warn(
       `Unable to find pdf2txt, the pdfminer executable on the system. Are you sure it is installed?`,
@@ -704,11 +698,21 @@ export function getExecLocationCommandOnSystem(): string {
 
 /**
  * returns the location of a command on a system.
- * @param executableName the name of the executable to be located
+ * @param firstChoice the first choice name of the executable to be located
+ * @param secondChoice the second choice name of the executable to be located
+ * @param thirdChoice the third choice name of the executable to be located
  */
-export function getCommandLocationOnSystem(executableName: string): string {
-  const info = spawnSync(getExecLocationCommandOnSystem(), [executableName]);
-  return info.status === 0 ? info.stdout.toString().split(os.EOL)[0] : null;
+export function getCommandLocationOnSystem(
+  firstChoice: string,
+  secondChoice: string = "",
+  thirdChoice: string = "",
+): string {
+  const info = spawnSync(getExecLocationCommandOnSystem(), [firstChoice]);
+  const result = info.status === 0 ? info.stdout.toString().split(os.EOL)[0] : null;
+  if (result === null && secondChoice !== "") {
+    return getCommandLocationOnSystem(secondChoice, thirdChoice);
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
[This recent pdfminer.six commit](https://github.com/pdfminer/pdfminer.six/commit/bc034c8e59d90e9b2cb8697a1d2fe9a33401761e#diff-147654f85909c4dee04d20e37ebb576f) requires pdf2txt.py to be executed like this:

> `python pdf2txt.py <args>`


Making necessary changes to be up to speed with the latest version.