### PR TITLE
Avoid UI to crash when image is detected in a document

### DIFF
--- a/demo/vue-viewer/src/components/ElementSelector.vue
+++ b/demo/vue-viewer/src/components/ElementSelector.vue
@@ -41,12 +41,14 @@ export default {
       var flattend = [];
       !(function flat(element, buildID) {
         flattend.push({ text: buildID(element), value: element });
-        element.content.forEach(function(el) {
-          flattend.push({ text: buildID(el), value: el });
-          if (Array.isArray(el.content)) {
-            flat(el, buildID);
-          }
-        });
+        if (element.content) {
+          element.content.forEach(function(el) {
+            flattend.push({ text: buildID(el), value: el });
+            if (Array.isArray(el.content)) {
+              flat(el, buildID);
+            }
+          });
+        }
       })(element, this.buildID);
       return flattend;
     },

--- a/demo/vue-viewer/src/components/FontInspector.vue
+++ b/demo/vue-viewer/src/components/FontInspector.vue
@@ -15,6 +15,7 @@
                   {{ fontKey }}: <span class="fontValue">{{ font[fontKey] }}</span>
                   <br />
                 </span>
+                <span>Ratio: {{ fontUsageRatio(font.id) }}</span>
               </li>
             </ul>
           </div>
@@ -28,7 +29,7 @@
 import { mapMutations, mapGetters } from 'vuex';
 export default {
   computed: {
-    ...mapGetters(['fontInspectorSwitchState', 'fonts']),
+    ...mapGetters(['fontInspectorSwitchState', 'fonts', 'fontUsageRatio']),
     fontInspectorSwitch: {
       get() {
         return this.fontInspectorSwitchState;

--- a/demo/vue-viewer/src/vuex/store.js
+++ b/demo/vue-viewer/src/vuex/store.js
@@ -224,5 +224,41 @@ export default new Vuex.Store({
     fontInspectorSwitchState(state) {
       return state.expansionPanels.fontInspector;
     },
+    fontUsageRatio: state => fontId => {
+      const flattenElement = element => {
+        var flattend = [];
+        !(function flat(element) {
+          flattend.push(element);
+          if (element.content) {
+            element.content.forEach(function(el) {
+              flattend.push(el);
+              if (Array.isArray(el.content)) {
+                flat(el);
+              }
+            });
+          }
+        })(element);
+        return flattend;
+      };
+      //console.log('Search words with font ' + fontId);
+      const allWords = state.document.pages
+        .map(page => page.elements)
+        .reduce((prev, curr) => prev.concat(curr), [])
+        .map(flattenElement)
+        .reduce((prev, curr) => prev.concat(curr), [])
+        .filter(element => element.type == 'word');
+
+      const wordsWithFont = allWords.filter(w => w.font == fontId);
+      //console.log('Words with font ' + wordsWithFont.length);
+      //console.log('Total Words ' + allWords.length);
+      return (
+        Number(wordsWithFont.length / allWords.length).toFixed(3) +
+        ' (' +
+        wordsWithFont.length +
+        '/' +
+        allWords.length +
+        ')'
+      );
+    },
   },
 });


### PR DESCRIPTION
Javascript error is thrown in UI when a document contains images.

![Screenshot 2019-11-08 at 10 03 03](https://user-images.githubusercontent.com/12429149/68463471-fca9b700-020e-11ea-82f1-a06ff6f03650.png)


To reproduce:
- Run parsr with benchmark/dataset/Samples_of_descriptive_paragraphs.pdf
- Go to page 2
- See console