### PR TITLE
[Vue] - added recursive getter for element contents

### DIFF
--- a/demo/vue-viewer/src/components/ElementInspector.vue
+++ b/demo/vue-viewer/src/components/ElementInspector.vue
@@ -23,8 +23,9 @@
                 <span>Font:</span> {{ currentElement.font }}
                 <span>{{ fontInfo(currentElement.font) }}</span>
               </li>
-              <li v-if="!Array.isArray(currentElement.content)">
-                <span>Content:</span> <span class="wordContent">{{ currentElement.content }}</span>
+              <li>
+                <span>Content:</span>
+                <span class="wordContent">{{ recursiveGetContent(currentElement.content) }}</span>
               </li>
               <li v-if="Object.keys(currentElement.properties).length > 0">
                 <span>Properties:</span>
@@ -101,6 +102,16 @@ export default {
       const font = this.fonts.filter(font => font.id === fontId).shift();
       if (font) {
         return '(' + font.name + ', ' + font.weight + ', size ' + font.size + ')';
+      }
+      return null;
+    },
+    recursiveGetContent(content) {
+      if (typeof content === 'string') {
+        return content;
+      } else if (Array.isArray(content)) {
+        return content.map(c => this.recursiveGetContent(c)).join(' ');
+      } else if (typeof content === 'object') {
+        return this.recursiveGetContent(content.content || '');
       }
       return null;
     },


### PR DESCRIPTION
In the UI, when an element's content was an Array of other elements, we were not able to inspect the contents inside that Array.

This PR does a deep-search for 'content' values inside Arrays or Objects and returns it as a string.

This is specially useful for inspecting a Cell or Row inside tables, but it's applied for every type of element available.

<img width="1081" alt="Screenshot 2019-11-12 at 14 04 19" src="https://user-images.githubusercontent.com/11478307/68674106-7dd9b480-0555-11ea-90c4-d4db781831ed.png">
