### PR TITLE
[HeadingToMD] - unlimited MD heading level

### DIFF
--- a/server/src/types/DocumentRepresentation/Heading.ts
+++ b/server/src/types/DocumentRepresentation/Heading.ts
@@ -57,7 +57,7 @@ export class Heading extends Paragraph {
    * Converts the entire paragraph into a string form with formatting, with spaces between words.
    */
   public toMarkdown(): string {
-    if (this.level === 0 || this.level > 6) {
+    if (this.level === 0) {
       return super.toMarkdown();
     }
     return '#'.repeat(this.level) + ' ' + this.toString();


### PR DESCRIPTION
removed condition that limited the heading level to max 6 when converting to Markdown