### PR TITLE
update the documentation for installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,8 +31,9 @@ Under a **Debian** based distribution:
 ```sh
 sudo add-apt-repository ppa:ubuntuhandbook1/apps
 sudo apt-get update
-sudo apt-get install nodejs npm qpdf imagemagick graphicsmagick python-pdfminer tesseract-ocr libtesseract-dev python3-tk ghostscript python3-pip
+sudo apt-get install nodejs npm qpdf imagemagick graphicsmagick tesseract-ocr libtesseract-dev python3-tk ghostscript python3-pip
 pip install camelot-py
+pip install pdfminer.six
 ```
 
 Under **Arch** Linux :


### PR DESCRIPTION
add pdfminer.six in the dependencies when installing on a debian based distribution