### PR TITLE
Image optimisation before tesseract scan

### DIFF
--- a/demo/vue-viewer/src/components/DocumentPreview/Page.vue
+++ b/demo/vue-viewer/src/components/DocumentPreview/Page.vue
@@ -7,52 +7,48 @@
       :width="page.box.w"
       :height="page.box.h"
     >
-      <!--text x="10" y="20" fill="red">
-				Debug Info: Page {{ page.pageNumber }} - Viewer Zoom {{ zoom }} - Page Zoom to fit
-				{{ zoomToFitPage }}
-			</text-->
-      <!--pageElements
-				v-for="element in page.elements"
-				:key="element.id"
-				:element="element"
-				:fonts="fonts"
-			/-->
-      <heading
-        v-for="element in elementsOfType('heading')"
-        :key="element.id"
-        :element="element"
-        :fonts="fonts"
-        @custom-event="elementSelected"
-      />
-      <paragraph
-        v-for="element in elementsOfType('paragraph')"
-        :key="element.id"
-        :element="element"
-        :fonts="fonts"
-        @custom-event="elementSelected"
-      />
-      <tableData
-        v-for="element in elementsOfType('table')"
-        :key="element.id"
-        :element="element"
-        :fonts="fonts"
-        @custom-event="elementSelected"
-      />
-      <list
-        v-for="element in elementsOfType('list')"
-        :key="element.id"
-        :element="element"
-        :fonts="fonts"
-        @custom-event="elementSelected"
-      />
-      <!--component
-				v-for="element in page.elements"
-				:functional="true"
-				:is="componentFor(element)"
-				:key="element.id"
-				:element="element"
-				:fonts="fonts"
-			></component-->
+      <g
+        :style="{
+          transform:
+            'translateX(' +
+            page.rotation.translation.x +
+            'px) translateY(' +
+            page.rotation.translation.y +
+            'px) rotate(' +
+            page.rotation.degrees +
+            'deg)',
+          transformOrigin: page.rotation.origin.x + 'px ' + page.rotation.origin.y + 'px',
+        }"
+      >
+        <heading
+          v-for="element in elementsOfType('heading')"
+          :key="element.id"
+          :element="element"
+          :fonts="fonts"
+          @custom-event="elementSelected"
+        />
+        <paragraph
+          v-for="element in elementsOfType('paragraph')"
+          :key="element.id"
+          :element="element"
+          :fonts="fonts"
+          @custom-event="elementSelected"
+        />
+        <tableData
+          v-for="element in elementsOfType('table')"
+          :key="element.id"
+          :element="element"
+          :fonts="fonts"
+          @custom-event="elementSelected"
+        />
+        <list
+          v-for="element in elementsOfType('list')"
+          :key="element.id"
+          :element="element"
+          :fonts="fonts"
+          @custom-event="elementSelected"
+        />
+      </g>
     </svg>
   </div>
 </template>

--- a/demo/vue-viewer/src/components/Thumbnails.vue
+++ b/demo/vue-viewer/src/components/Thumbnails.vue
@@ -65,7 +65,12 @@ export default {
   computed: {
     ...mapState(['inputFileName']),
     canShowThumbnails() {
-      return ['pdf', 'jpg', 'jpeg', 'png'].includes(this.inputFileName.split('.').pop());
+      return ['pdf', 'jpg', 'jpeg', 'png', 'tiff'].includes(
+        this.inputFileName
+          .toLowerCase()
+          .split('.')
+          .pop(),
+      );
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "csv-stringify": "^5.3.3",
     "file-type": "^9.0.0",
     "html-entities": "^1.2.1",
-    "jimp": "^0.8.5",
     "pino": "^5.13.2",
     "pino-pretty": "^2.6.1",
     "request": "^2.88.0",

--- a/server/assets/ImageCorrection.py
+++ b/server/assets/ImageCorrection.py
@@ -9,7 +9,6 @@ import numpy as np
 import cv2 as cv
 import json
 import math
-from scipy import ndimage
 from pathlib import Path
 
 import re

--- a/server/assets/ImageCorrection.py
+++ b/server/assets/ImageCorrection.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+"""
+This script performs all (TODO Deskewing) steps to improve Tesseract accuracy:
+See --> https://github.com/tesseract-ocr/tesseract/wiki/ImproveQuality
+"""
+from __future__ import print_function
+
+import numpy as np
+import cv2 as cv
+import json
+import math
+from scipy import ndimage
+
+# built-in modules
+import os
+import sys
+
+
+def transparentToWhite(image):
+    # If alpha transparency
+    if(image.shape[2] == 4):
+        #convert transparent to white
+        alpha_channel = image[:, :, 3]
+        _, mask = cv.threshold(alpha_channel, 254, 255, cv.THRESH_BINARY)  # binarize mask
+        color = image[:, :, :3]
+        image = cv.bitwise_not(cv.bitwise_not(color, mask=np.uint8(mask)))
+
+    return image
+
+def removeShadow(image):
+    rgb_planes = cv.split(image)
+    result_planes = []
+    for plane in rgb_planes:
+        dilated_img = cv.dilate(plane, np.ones((9,9), np.uint8))
+        bg_img = cv.medianBlur(dilated_img, 11)
+        diff_img = 255 - cv.absdiff(plane, bg_img)
+        result_planes.append(diff_img)
+
+        # dilated_img = cv.dilate(plane, np.ones((4,4), np.uint8))
+        # bg_img = cv.medianBlur(dilated_img, 7)
+        # diff_img = 255 - cv.absdiff(plane, bg_img)
+        # result_planes.append(diff_img)
+
+    return cv.merge(result_planes)
+
+def detectRotation(image):
+    img_gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
+    img_edges = cv.Canny(img_gray, 100, 100, apertureSize=3)
+    lines = cv.HoughLinesP(img_edges, 1, math.pi / 180.0, 100, minLineLength=100, maxLineGap=5)
+
+    angles = []
+    for line in lines:
+        for x1, y1, x2, y2 in line:
+            #cv2.line(image, (x1, y1), (x2, y2), (255, 255, 0), 1)
+            angle = math.degrees(math.atan2(y2 - y1, x2 - x1))
+            angles.append(angle)
+
+    median_angle = np.median(angles)
+    return median_angle
+
+def getRotationData(originalImage, rotatedImage, angle, outputFile):
+    (oh, ow) = originalImage.shape[:2]
+    (rh, rw) = rotatedImage.shape[:2]
+    outputData = dict()
+    origin = dict()
+    origin['x'] = str(int(rw/2))
+    origin['y'] = str(int(rh/2))
+    outputData['origin'] = origin
+    translation = dict()
+    translation['x'] = str(int((ow-rw)/2))
+    translation['y'] = str(int((oh-rh)/2))
+    outputData['translation'] = translation
+    outputData['degrees'] = str(int(angle))
+    outputData['filename'] = outputFile
+
+    return json.dumps(outputData)
+
+def main():
+    try:
+        src = sys.argv[1]
+        originalImage = cv.imread(src, cv.IMREAD_UNCHANGED)
+
+        # Remove transparency from pngs
+        noTransparentImage = transparentToWhite(originalImage);
+        # Image Rotation
+        angle = detectRotation(noTransparentImage)
+        rotatedImage = ndimage.rotate(noTransparentImage, angle, cval=255)
+        # Remove shadows
+        shadowsOut = removeShadow(rotatedImage)
+        shadowsOut = cv.copyMakeBorder(shadowsOut, 2, 2, 2, 2, cv.BORDER_CONSTANT, value=[1, 0, 0])
+        #save cropped image
+        outputFile = src.split('.')[0]+'-corrected.'+'.'.join(src.split('.')[1:])
+        cv.imwrite(outputFile, shadowsOut)
+        
+        
+        print(getRotationData(originalImage, rotatedImage, angle, outputFile))
+        sys.stdout.flush()
+        sys.exit(0)
+
+    except Exception as e:
+        print(e)
+        sys.stdout.flush()
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -72,7 +72,7 @@ function main(): void {
       fs.mkdirSync(outputFolder);
     } catch (err) {
       logger.error(`Error creating the requested output folder ${outputFolder}: ${err}`);
-      throw(err);
+      throw err;
     }
   }
   const documentName: string = commander.documentName;
@@ -125,7 +125,9 @@ function main(): void {
       .run(filePath)
       .then((doc: Document) => {
         if (fileTypeInfo.ext === 'pdf' && isDocumentImageBased(doc)) {
-          logger.info(`Since the input file is a PDF with only images, trying to run an OCR on all pages...`);
+          logger.info(
+            `Since the input file is a PDF with only images, trying to run an OCR on all pages...`,
+          );
           if (config.extractor.img === 'tesseract') {
             filePath = pdfToImage(filePath);
             orchestrator = new Orchestrator(new TesseractExtractor(config), cleaner);
@@ -212,7 +214,9 @@ function main(): void {
    * This is true for example, in the case of scanned documents as PDFs
    */
   function isDocumentImageBased(doc: Document): boolean {
-    return !doc.pages.map(p => (p.elements.length === 1) && (p.elements[0] instanceof Image)).includes(false);
+    return !doc.pages
+      .map(p => p.elements.length === 1 && p.elements[0] instanceof Image)
+      .includes(false);
   }
 
   /**
@@ -263,11 +267,9 @@ function main(): void {
    */
   function pdfToImage(pdfPath: string): string {
     const tifFilePath = pdfPath + '.tiff';
-    const ret = utils.spawnSync( utils.getConvertLocation(), [
+    const ret = utils.spawnSync(utils.getConvertLocation(), [
       '-density',
-      '200x200',
-      '-compress',
-      'Fax',
+      '300x300',
       pdfPath,
       tifFilePath,
     ]);

--- a/server/src/input/tesseract/TesseractExtractor.ts
+++ b/server/src/input/tesseract/TesseractExtractor.ts
@@ -28,7 +28,7 @@ export class TesseractExtractor extends Extractor {
    * @param inputFile The name of the image to be used at input for the extraction.
    * @returns The promise of a valid Document (as per the Document Representation namespace).
    */
-  public run(inputFile: string, rotationCorrection: boolean = false): Promise<Document> {
+  public run(inputFile: string, rotationCorrection: boolean = true): Promise<Document> {
     return tesseract2json
       .execute(inputFile, rotationCorrection, this.config)
       .then((doc: Document) => setPageDimensions(doc, inputFile));

--- a/server/src/output/json/JsonExporter.ts
+++ b/server/src/output/json/JsonExporter.ts
@@ -275,12 +275,20 @@ export class JsonExporter extends Exporter {
   }
 
   private rotationToJsonRotation(rotation: utils.RotationCorrection): JsonPageRotation {
-    const jsonRotation: JsonPageRotation = {
-      degrees: rotation.degrees,
-      origin: rotation.origin,
-      translation: rotation.translation,
+    if (rotation != null) {
+      const jsonRotation: JsonPageRotation = {
+        degrees: rotation.degrees,
+        origin: rotation.origin,
+        translation: rotation.translation,
+      };
+      return jsonRotation;
+    }
+    const noRotation: JsonPageRotation = {
+      degrees: 0,
+      origin: { x: 0, y: 0 },
+      translation: { x: 0, y: 0 },
     };
-    return jsonRotation;
+    return noRotation;
   }
 
   private convertElementValue(value: any): any {

--- a/server/src/output/json/JsonExporter.ts
+++ b/server/src/output/json/JsonExporter.ts
@@ -30,6 +30,7 @@ import {
   JsonFont,
   JsonMetadata,
   JsonPage,
+  JsonPageRotation,
   List,
   Page,
   Table,
@@ -72,6 +73,7 @@ export class JsonExporter extends Exporter {
     this.json.pages = this.doc.pages.map((page: Page) => {
       const jsonPage: JsonPage = {
         box: this.boxToJsonBox(page.box),
+        rotation: this.rotationToJsonRotation(page.pageRotation),
         pageNumber: page.pageNumber,
         elements: page.elements
           .sort(utils.sortElementsByOrder)
@@ -253,7 +255,7 @@ export class JsonExporter extends Exporter {
       jsonElement.codeType = element.type;
       jsonElement.codeValue = element.content;
     } else if (element instanceof Image) {
-      jsonElement.src = element.src;  // TODO replace this with a location based on an API access point
+      jsonElement.src = element.src; // TODO replace this with a location based on an API access point
     } else if (element instanceof Heading) {
       jsonElement.level = element.level;
     }
@@ -270,6 +272,15 @@ export class JsonExporter extends Exporter {
     };
 
     return jsonBox;
+  }
+
+  private rotationToJsonRotation(rotation: utils.RotationCorrection): JsonPageRotation {
+    const jsonRotation: JsonPageRotation = {
+      degrees: rotation.degrees,
+      origin: rotation.origin,
+      translation: rotation.translation,
+    };
+    return jsonRotation;
   }
 
   private convertElementValue(value: any): any {

--- a/server/src/types/DocumentRepresentation/JsonExport.ts
+++ b/server/src/types/DocumentRepresentation/JsonExport.ts
@@ -23,8 +23,20 @@ export interface JsonExport {
   metadata: JsonMetadata[];
 }
 
+export interface JsonPageRotationCoords {
+  x: number;
+  y: number;
+}
+
+export interface JsonPageRotation {
+  degrees: number;
+  origin: JsonPageRotationCoords;
+  translation: JsonPageRotationCoords;
+}
+
 export interface JsonPage {
   box: JsonBox;
+  rotation?: JsonPageRotation;
   pageNumber: number;
   elements: JsonElement[];
 }

--- a/server/src/types/DocumentRepresentation/Page.ts
+++ b/server/src/types/DocumentRepresentation/Page.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { findMostCommonFont, isInBox } from '../../utils';
+import { findMostCommonFont, isInBox, RotationCorrection } from '../../utils';
 import logger from '../../utils/Logger';
 import { BoundingBox } from './BoundingBox';
 import { Element } from './Element';
@@ -58,6 +58,7 @@ export class Page {
   private _box: BoundingBox;
   private _horizontalOccupancy: boolean[];
   private _verticalOccupancy: boolean[];
+  private _pageRotation: RotationCorrection;
 
   constructor(pageNumber: number, elements: Element[], boundingBox: BoundingBox) {
     this.pageNumber = pageNumber;
@@ -65,7 +66,7 @@ export class Page {
     this.box = boundingBox;
     this.horizontalOccupancy = [];
     this.verticalOccupancy = [];
-
+    this.pageRotation = null;
     this.computePageOccupancy();
   }
 
@@ -279,6 +280,22 @@ export class Page {
    */
   public set box(value: BoundingBox) {
     this._box = value;
+  }
+
+  /**
+   * Setter PageRotation
+   * @param {ImageCorrection} value
+   */
+  public set pageRotation(value: RotationCorrection) {
+    this._pageRotation = value;
+  }
+
+  /**
+   * Getter PageRotation
+   * @return {ImageCorrection}
+   */
+  public get pageRotation(): RotationCorrection {
+    return this._pageRotation;
   }
 
   /**


### PR DESCRIPTION
This PR tries to optimise images before run tesseract.
1) Detect and fix rotation to use 0 degrees rotated images in tesseract
2) Detect text face direction to ensure text is face up before run tesseract
3) Removes shadow images to improve Tesseract accuracy

![Card](https://user-images.githubusercontent.com/12429149/70130234-77d08280-1680-11ea-82b8-c8fb6f21ea1a.png)

![Shadows_Out](https://user-images.githubusercontent.com/12429149/70130250-7dc66380-1680-11ea-904d-3f86ebea3d34.png)

![Bank](https://user-images.githubusercontent.com/12429149/70130261-83bc4480-1680-11ea-8e86-d02e07f14ee9.png)

