### PR TITLE
Out of page removal & image rotation

### DIFF
--- a/server/assets/ImageCorrection.py
+++ b/server/assets/ImageCorrection.py
@@ -101,7 +101,7 @@ def getRotationData(originalImage, rotatedImage, angle, outputFile):
     return json.dumps(outputData)
 
 def isFaceDown(imagePath):
-    tesseractOutput = subprocess.Popen(['tesseract', imagePath, "-", "--psm", "0", "-c", "min_characters_to_try=10"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, bufsize=1, universal_newlines=True).stdout.read()
+    tesseractOutput = subprocess.Popen(['tesseract', imagePath, "-", "--psm", "0"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, bufsize=1, universal_newlines=True).stdout.read()
     tesseractRotation = re.search('(?<=Rotate: )\d+', tesseractOutput).group(0)
     if tesseractRotation != '0':
         return True

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -266,12 +266,16 @@ function main(): void {
    * @returns The Orchestrator instance
    */
   function pdfToImage(pdfPath: string): string {
-    const tifFilePath = pdfPath + '.tiff';
+    const outPutFilePath = pdfPath + '.tiff';
     const ret = utils.spawnSync(utils.getConvertLocation(), [
       '-density',
       '300x300',
+      '-compress',
+      'None',
+      '-alpha',
+      'off',
       pdfPath,
-      tifFilePath,
+      outPutFilePath,
     ]);
 
     if (ret.status !== 0) {
@@ -281,7 +285,7 @@ function main(): void {
       );
     }
 
-    return tifFilePath;
+    return outPutFilePath;
   }
 }
 

--- a/server/src/types/DocumentRepresentation/Page.ts
+++ b/server/src/types/DocumentRepresentation/Page.ts
@@ -284,7 +284,7 @@ export class Page {
 
   /**
    * Setter PageRotation
-   * @param {ImageCorrection} value
+   * @param {RotationCorrection} value
    */
   public set pageRotation(value: RotationCorrection) {
     this._pageRotation = value;
@@ -292,7 +292,7 @@ export class Page {
 
   /**
    * Getter PageRotation
-   * @return {ImageCorrection}
+   * @return {RotationCorrection}
    */
   public get pageRotation(): RotationCorrection {
     return this._pageRotation;

--- a/tslint.json
+++ b/tslint.json
@@ -1,25 +1,21 @@
 {
-	"defaultSeverity": "error",
-	"extends": "tslint:recommended",
-  	"linterOptions": {
-      	"exclude": [
-			"dist",
-			"api/dist",
-			"server/src/processing/HeadingDetectionModuleDT/model.js"
-		]
-  	},
-	"jsRules": {},
-	"rules": {        
-		"quotemark": false,
-		"interface-over-type-literal": [false],
-		"interface-name": [true, "never-prefix"],
-		"indent": [true, "spaces", 2],
-		"forin": false,
-		"arrow-parens": false,
-		"object-literal-key-quotes": false,
-		"adjacent-overload-signatures": false,
-		"variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
-		"object-literal-sort-keys": [false]
-	},
-	"rulesDirectory": []
+  "defaultSeverity": "error",
+  "extends": "tslint:recommended",
+  "linterOptions": {
+    "exclude": ["dist", "api/dist", "server/src/processing/HeadingDetectionDTModule/model.js"]
+  },
+  "jsRules": {},
+  "rules": {
+    "quotemark": false,
+    "interface-over-type-literal": [false],
+    "interface-name": [true, "never-prefix"],
+    "indent": [true, "spaces", 2],
+    "forin": false,
+    "arrow-parens": false,
+    "object-literal-key-quotes": false,
+    "adjacent-overload-signatures": false,
+    "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
+    "object-literal-sort-keys": [false]
+  },
+  "rulesDirectory": []
 }


### PR DESCRIPTION
Fixed bug that was removing words from a page with rotated content.

When we rotate a page to get best tesseract accuracy we need to use rotated box instead of page box to filter elements that are out out of page.

After
<img width="2032" alt="Screenshot 2019-12-05 at 15 58 18" src="https://user-images.githubusercontent.com/12429149/70248101-bb0f1c00-177a-11ea-8162-91957aae8316.png">

Before
<img width="2032" alt="Screenshot 2019-12-05 at 13 57 34" src="https://user-images.githubusercontent.com/12429149/70248185-d7ab5400-177a-11ea-8673-6af73ff9c4a2.png">

