### PR TITLE
Tesseract & multi pages PDF's

### DIFF
--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -269,14 +269,16 @@ function main(): void {
    * @returns The Orchestrator instance
    */
   function pdfToImage(pdfPath: string): string {
-    const outPutFilePath = pdfPath + '.tiff';
+    const outPutFilePath = pdfPath + '_%03.tiff';
     const ret = utils.spawnSync(utils.getConvertLocation(), [
       '-density',
       '300x300',
       '-compress',
-      'None',
+      'lzw',
       '-alpha',
-      'off',
+      'remove',
+      '-background',
+      'white',
       pdfPath,
       outPutFilePath,
     ]);

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -65,7 +65,7 @@ function main(): void {
 
   printVersion();
 
-  let filePath: string = path.resolve(commander.inputFile);
+  const filePath: string = path.resolve(commander.inputFile);
   const outputFolder: string = path.resolve(commander.outputFolder);
   if (!fs.existsSync(outputFolder)) {
     logger.info(`Requested output folder ${outputFolder} did not exist. Creating... `);
@@ -130,7 +130,6 @@ function main(): void {
             `Since the input file is a PDF with only images, trying to run an OCR on all pages...`,
           );
           if (config.extractor.img === 'tesseract') {
-            filePath = pdfToImage(filePath);
             orchestrator = new Orchestrator(new TesseractExtractor(config), cleaner);
           } else {
             orchestrator = new Orchestrator(new AbbyyTools(config), cleaner);
@@ -229,7 +228,6 @@ function main(): void {
     if (config.extractor.pdf === 'abbyy') {
       return new Orchestrator(new AbbyyTools(config), cleaner);
     } else if (config.extractor.pdf === 'tesseract') {
-      filePath = pdfToImage(filePath);
       return new Orchestrator(new TesseractExtractor(config), cleaner);
     } else if (config.extractor.pdf === 'pdfjs') {
       return new Orchestrator(new PDFJsExtractor(config), cleaner);
@@ -260,37 +258,6 @@ function main(): void {
     } else {
       return new Orchestrator(new AbbyyTools(config), cleaner);
     }
-  }
-
-  /**
-   * Returns the pdf file extraction orchestrator using tesseract as the extractor.
-   * First, the pdf is sampled for it to be converted into an image, then, an image extraction orchestrator is returned.
-   *
-   * @returns The Orchestrator instance
-   */
-  function pdfToImage(pdfPath: string): string {
-    const outPutFilePath = pdfPath + '_%03.tiff';
-    const ret = utils.spawnSync(utils.getConvertLocation(), [
-      '-density',
-      '300x300',
-      '-compress',
-      'lzw',
-      '-alpha',
-      'remove',
-      '-background',
-      'white',
-      pdfPath,
-      outPutFilePath,
-    ]);
-
-    if (ret.status !== 0) {
-      logger.error(ret.stderr);
-      throw new Error(
-        'ImageMagick failure: impossible to convert pdf to images (is ImageMagick installed?)',
-      );
-    }
-
-    return outPutFilePath;
   }
 }
 

--- a/server/src/input/tesseract/TesseractExtractor.ts
+++ b/server/src/input/tesseract/TesseractExtractor.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { Document } from '../../types/DocumentRepresentation';
+import * as utils from '../../utils';
 import { Extractor } from '../Extractor';
 import { setPageDimensions } from '../set-page-dimensions';
 import * as tesseract2json from './tesseract2json';
@@ -29,8 +32,65 @@ export class TesseractExtractor extends Extractor {
    * @returns The promise of a valid Document (as per the Document Representation namespace).
    */
   public run(inputFile: string, rotationCorrection: boolean = true): Promise<Document> {
+    return this.scanPages(this.pdfToImages(inputFile), rotationCorrection).then((doc: Document) => {
+      doc.inputFile = inputFile;
+      return doc;
+    });
+  }
+
+  private scanPage(page: string, fixRotation: boolean): Promise<Document> {
     return tesseract2json
-      .execute(inputFile, rotationCorrection, this.config)
-      .then((doc: Document) => setPageDimensions(doc, inputFile));
+      .execute(page, fixRotation, this.config)
+      .then((doc: Document) => setPageDimensions(doc, page));
+  }
+
+  private scanPages(
+    pages: string[],
+    fixRotation: boolean,
+    allPagesDoc: Document = new Document([]),
+    index: number = 0,
+  ): Promise<Document> {
+    return this.scanPage(pages[index], fixRotation).then((doc: Document) => {
+      allPagesDoc.pages = allPagesDoc.pages.concat(doc.pages);
+      allPagesDoc.pages[index].pageNumber = index + 1;
+      if (pages.length > index + 1) {
+        return this.scanPages(pages, fixRotation, allPagesDoc, index + 1);
+      } else {
+        return allPagesDoc;
+      }
+    });
+  }
+
+  private pdfToImages(pdfPath: string): string[] {
+    const folder = path.dirname(pdfPath).concat('/samples');
+    try {
+      fs.mkdirSync(folder);
+    } catch (e) {
+      throw e;
+    }
+    const outPutFilePath = folder + '/Sample_%03d.tiff';
+
+    const ret = utils.spawnSync(utils.getConvertLocation(), [
+      '-density',
+      '300x300',
+      '-compress',
+      'lzw',
+      '-alpha',
+      'remove',
+      '-background',
+      'white',
+      pdfPath,
+      outPutFilePath,
+    ]);
+
+    if (ret.status !== 0) {
+      const errorMessage = [
+        'ImageMagick failure: impossible to convert pdf to images (is ImageMagick installed?)',
+        ret.stderr.toString(),
+      ];
+      throw new Error(errorMessage.join('\n'));
+    }
+
+    return fs.readdirSync(folder).map(file => path.join(folder, file));
   }
 }

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -235,9 +235,6 @@ export async function correctImageForRotation(srcImg: string): Promise<RotationC
     const args: string[] = [path.join(__dirname, '../assets/ImageCorrection.py'), srcImg];
     const ret = spawnSync(pythonLocation, args);
     if (ret.status !== 0) {
-      logger.warn('ret.stdout ' + JSON.stringify(ret.stdout));
-      logger.warn('ret.stderr ' + JSON.stringify(ret.stderr));
-      logger.warn('Command python3 ' + args.join(' '));
       logger.warn(
         `Error running image rotation calculation: ${ret.stderr}.. using the original image.`,
       );


### PR DESCRIPTION
Allow tesseract to OCR pdfs with more than one page, also optimised Pdf to Image (magick convert) to generate better resolution and lower weight images to use in tesseract.

<img width="1489" alt="ConvertOptimisation" src="https://user-images.githubusercontent.com/12429149/70541904-23d60a00-1b68-11ea-9cce-49c8ef7bbb22.png">

Test pdf --> 
[fbiletter.pdf](https://github.com/axa-group/Parsr/files/3945556/fbiletter.pdf)

