### PR TITLE
Fix test execution crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ __pycache__
 
 # temporary output folder in the root - by default used for temporary output storage in launch.json
 tmp
+
+# test directories containing temp data
+test/assets/samples

--- a/server/src/input/tesseract/TesseractExtractor.ts
+++ b/server/src/input/tesseract/TesseractExtractor.ts
@@ -64,7 +64,9 @@ export class TesseractExtractor extends Extractor {
   private pdfToImages(pdfPath: string): string[] {
     const folder = path.dirname(pdfPath).concat('/samples');
     try {
-      fs.mkdirSync(folder);
+      if (!fs.existsSync(folder)) {
+        fs.mkdirSync(folder);
+      }
     } catch (e) {
       throw e;
     }


### PR DESCRIPTION
- Skip creating directory to save tesseract optimised images if it already exist
- Updated git ignore to add folder --> /test/assets/samples