### PR TITLE
[fix] - extra dependencies added to Dockerfile

### DIFF
--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10 as engine
 
 RUN  apt-get update \
-  && apt-get install -y wget gnupg2 \
+  && apt-get install -y wget gnupg2 libasound2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)

--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10 as engine
 
 RUN  apt-get update \
-  && apt-get install gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+  && apt-get install -y gnupg2 gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget \
   && rm -rf /var/lib/apt/lists/*
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)

--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -1,5 +1,19 @@
 FROM debian:10 as engine
 
+RUN  apt-get update \
+  && apt-get install -y wget gnupg2 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt-get update && \
     apt-get install -y imagemagick graphicsmagick mupdf mupdf-tools qpdf pandoc tesseract-ocr-all nodejs npm python-pdfminer python-pip python3-pip python-tk python3-pdfminer python3-opencv && \
     pip install ghostscript camelot-py scikit-image numpy pillow && \

--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10 as engine
 
 RUN  apt-get update \
-  && apt-get install -y wget gnupg2 libasound2 \
+  && apt-get install gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
   && rm -rf /var/lib/apt/lists/*
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,9 +204,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.9.tgz",
-      "integrity": "sha512-+6VygF9LbG7Gaqeog2G7u1+RUcmo0q1rI+2ZxdIg2fAUngk5Vz9fOCHXdloNUOHEPd1EuuOpL5O0CdgN9Fx5UQ=="
+      "version": "10.17.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.10.tgz",
+      "integrity": "sha512-K9E84otvA2HQBTp0TWPwWf/986N6v0v7ers6q7wL48w5SXKzYjqlYkaxHYMwWRzQdgZg5p6eI7L0D6FLJYY7ag=="
     },
     "@types/pdfjs-dist": {
       "version": "2.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -947,6 +947,50 @@
       "requires": {
         "lodash": "^4.17.15",
         "puppeteer": "^1.19.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "puppeteer": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+          "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+          "requires": {
+            "debug": "^4.1.0",
+            "extract-zip": "^1.6.6",
+            "https-proxy-agent": "^2.2.1",
+            "mime": "^2.0.3",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "rimraf": "^2.6.1",
+            "ws": "^6.1.0"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -3543,13 +3587,13 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
-      "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.0.0.tgz",
+      "integrity": "sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==",
       "requires": {
         "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "^3.0.0",
         "mime": "^2.0.3",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
@@ -3563,25 +3607,6 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "pdfjs-dist": "^2.2.228",
     "pino": "^5.13.2",
     "pino-pretty": "^2.6.1",
+    "puppeteer": "^2.0.0",
     "request": "^2.88.0",
     "string-similarity": "^1.2.1",
     "svgson": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "pdfjs-dist": "^2.2.228",
     "pino": "^5.13.2",
     "pino-pretty": "^2.6.1",
-    "puppeteer": "^2.0.0",
     "request": "^2.88.0",
     "string-similarity": "^1.2.1",
     "svgson": "^3.1.0",

--- a/server/src/input/email/EmailExtractor.ts
+++ b/server/src/input/email/EmailExtractor.ts
@@ -48,6 +48,9 @@ export class EmailExtractor extends Extractor {
       const toPDF = new HTMLToPDF(
         (raw.html || '').concat(styles),
         {
+          browserOptions: {
+            args: ['--no-sandbox', '--font-render-hinting=none'],
+          },
           pdfOptions: {
             width: page.width,
             height: page.height,

--- a/test/unit/input-extractors.spec.ts
+++ b/test/unit/input-extractors.spec.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { withData } from 'leche';
 import 'mocha';
-// import { EmailExtractor } from '../../server/src/input/email/EmailExtractor';
+import { EmailExtractor } from '../../server/src/input/email/EmailExtractor';
 import { PDFJsExtractor } from '../../server/src/input/pdf.js/PDFJsExtractor';
 import { LinesToParagraphModule } from '../../server/src/processing/LinesToParagraphModule/LinesToParagraphModule';
 import { OutOfPageRemovalModule } from '../../server/src/processing/OutOfPageRemovalModule/OutOfPageRemovalModule';
@@ -77,50 +77,50 @@ describe('PDF.js input module', () => {
     );
 });
 
-// describe('EML input module', () => {
-//     withData(
-//         {
-//             'one paragraph text extraction': [
-//                 'One_Paragraph.eml',
-//                 "**Lorem Ipsum** is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
-//             ],
-//         },
-//         (fileName, expectedText) => {
-//             let exportedText: string = '';
+describe('EML input module', () => {
+    withData(
+        {
+            'one paragraph text extraction': [
+                'One_Paragraph.eml',
+                "**Lorem Ipsum** is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+            ],
+        },
+        (fileName, expectedText) => {
+            let exportedText: string = '';
 
-//             before(done => {
-//                 const extractor = new EmailExtractor({
-//                     "version": 0.5,
-//                     "extractor": {
-//                         "pdf": "pdfjs",
-//                         "img": "tesseract",
-//                         "language": ["eng", "fra"],
-//                     },
-//                     "cleaner": [],
-//                     "output": {
-//                         "granularity": "word",
-//                         "includeMarginals": false,
-//                         "formats": {},
-//                     },
-//                 });
+            before(done => {
+                const extractor = new EmailExtractor({
+                    "version": 0.5,
+                    "extractor": {
+                        "pdf": "pdfjs",
+                        "img": "tesseract",
+                        "language": ["eng", "fra"],
+                    },
+                    "cleaner": [],
+                    "output": {
+                        "granularity": "word",
+                        "includeMarginals": false,
+                        "formats": {},
+                    },
+                });
 
-//                 extractor.run(ASSETS_DIR + fileName).then(document => {
-//                     runModules(document, [
-//                         new OutOfPageRemovalModule(),
-//                         new WhitespaceRemovalModule(),
-//                         new ReadingOrderDetectionModule(),
-//                         new WordsToLineModule(),
-//                         new LinesToParagraphModule(),
-//                     ]).then(doc => {
-//                         exportedText = doc.getElementsOfType<Paragraph>(Paragraph).map(p => p.toMarkdown()).join(' ');
-//                         done();
-//                     });
-//                 });
-//             });
+                extractor.run(ASSETS_DIR + fileName).then(document => {
+                    runModules(document, [
+                        new OutOfPageRemovalModule(),
+                        new WhitespaceRemovalModule(),
+                        new ReadingOrderDetectionModule(),
+                        new WordsToLineModule(),
+                        new LinesToParagraphModule(),
+                    ]).then(doc => {
+                        exportedText = doc.getElementsOfType<Paragraph>(Paragraph).map(p => p.toMarkdown()).join(' ');
+                        done();
+                    });
+                });
+            });
 
-//             it('EML extractor should export expected text', () => {
-//                 expect(exportedText).to.eq(expectedText);
-//             });
-//         },
-//     );
-// });
+            it('EML extractor should export expected text', () => {
+                expect(exportedText).to.eq(expectedText);
+            });
+        },
+    );
+});


### PR DESCRIPTION
 to correctly run Puppeteer (html2pdf tool used by EmailExtractor)

Edited: Drone fails because it does not rebuild the base image on a PR commit, and that is needed for this case to get the new required puppeteer dependencies. This should be safe to merge to develop.