### PR TITLE
[Multiwords-Commands] Multiword commands bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker pull axarev/parsr:master
 
 For the develop branch:
 ```sh
-docker pull axarev/parsr:latest
+docker pull axarev/parsr:master
 ```
 
 If you also wish to install the GUI for sending documents and visualising results:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker pull axarev/parsr:master
 
 For the develop branch:
 ```sh
-docker pull axarev/parsr:master
+docker pull axarev/parsr:latest
 ```
 
 If you also wish to install the GUI for sending documents and visualising results:

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -803,7 +803,7 @@ export function getCommandLocationOnSystem(
     return null;
   }
 
-  return firstChoice;
+  return [result , ...cmdComponents.slice(1, cmdComponents.length)].join(" ");
 }
 
 /**

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -803,7 +803,7 @@ export function getCommandLocationOnSystem(
     return null;
   }
 
-  return [result , ...cmdComponents.slice(1, cmdComponents.length)].join(" ");
+  return [firstChoice , ...cmdComponents.slice(1, cmdComponents.length)].join(" ");
 }
 
 /**


### PR DESCRIPTION
The command handler was not handling multiword commands properly. All words after the first keyword were being rejected, causing an error in primarily the Imagemagick commands.

Example: `magick convert` would be translated to `/usr/bin/magick` only, leaving the `convert` part out.

This PR fixes that.