### PR TITLE
[feature/page-margins] - added page margin visualization for the GUI

### DIFF
--- a/demo/vue-viewer/src/components/DocumentPreview/Page.vue
+++ b/demo/vue-viewer/src/components/DocumentPreview/Page.vue
@@ -7,6 +7,40 @@
       :width="page.box.w"
       :height="page.box.h"
     >
+      <svg v-show="pageMarginsFilter">
+        <line
+          stroke-dasharray="5,5"
+          :x1="page.margins.left"
+          :y1="0"
+          :x2="page.margins.left"
+          :y2="page.box.h"
+          style="stroke: #aeaeae"
+        />
+        <line
+          stroke-dasharray="5,5"
+          :x1="page.margins.right"
+          :y1="0"
+          :x2="page.margins.right"
+          :y2="page.box.h"
+          style="stroke: #aeaeae"
+        />
+        <line
+          stroke-dasharray="5,5"
+          :x1="0"
+          :y1="page.margins.top"
+          :x2="page.box.w"
+          :y2="page.margins.top"
+          style="stroke: #aeaeae"
+        />
+        <line
+          stroke-dasharray="5,5"
+          :x1="0"
+          :y1="page.margins.bottom"
+          :x2="page.box.w"
+          :y2="page.margins.bottom"
+          style="stroke: #aeaeae"
+        />
+      </svg>
       <g
         :style="{
           transform:
@@ -55,6 +89,7 @@
 
 <script>
 // import PageElements from '@/components/DocumentPreview/PageElements';
+import { mapGetters } from 'vuex';
 import scrollItemMixin from '@/mixins/scrollItemMixin.js';
 import Paragraph from '@/components/DocumentPreview/Paragraph';
 import Heading from '@/components/DocumentPreview/Heading';
@@ -87,6 +122,7 @@ export default {
     },
   },
   computed: {
+    ...mapGetters(['pageMarginsFilter']),
     headings() {
       return this.elementsOfType['heading'] || [];
     },

--- a/demo/vue-viewer/src/components/PageInspector.vue
+++ b/demo/vue-viewer/src/components/PageInspector.vue
@@ -57,6 +57,14 @@
               :hide-details="true"
               @change="swapFilters()"
             ></v-switch>
+            <v-switch
+              v-model="marginsFilter"
+              label="Page Margins"
+              class="switch"
+              color="indigo darken-3"
+              :hide-details="true"
+              @change="swapFilters()"
+            ></v-switch>
           </div>
         </v-expansion-panel-content>
       </v-expansion-panel>
@@ -75,6 +83,7 @@ export default {
       tablesFilter: this.filters.tables,
       headingsFilter: this.filters.headings,
       listsFilter: this.filters.lists,
+      marginsFilter: this.filters.margins,
     };
   },
   props: {
@@ -104,6 +113,7 @@ export default {
         tables: this.tablesFilter,
         headings: this.headingsFilter,
         lists: this.listsFilter,
+        margins: this.marginsFilter,
       };
       this.$store.commit('setInspectorFilters', newFilters);
     },

--- a/demo/vue-viewer/src/vuex/store.js
+++ b/demo/vue-viewer/src/vuex/store.js
@@ -302,6 +302,6 @@ export default new Vuex.Store({
     },
     pageMarginsFilter(state) {
       return state.inspectorFilters.margins;
-    }
+    },
   },
 });

--- a/demo/vue-viewer/src/vuex/store.js
+++ b/demo/vue-viewer/src/vuex/store.js
@@ -300,5 +300,8 @@ export default new Vuex.Store({
     fontUsageRatio(state) {
       return state.fontUsageRatioCache;
     },
+    pageMarginsFilter(state) {
+      return state.inspectorFilters.margins;
+    }
   },
 });

--- a/server/src/input/pdf.js/pdfjs.ts
+++ b/server/src/input/pdf.js/pdfjs.ts
@@ -86,7 +86,9 @@ async function loadPage(document: any, pageNum: number): Promise<Page> {
       - calculate each single word's BBox,
       - search for splitted words to join them together
 
-      MAtrix reference on page 142 of PDF doc https://via.hypothes.is/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf#annotations:SVudloF5EemLBgPm0gmY3Q
+      MAtrix reference on page 142 of PDF doc
+      https://via.hypothes.is/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/
+      PDFReference.pdf#annotations:SVudloF5EemLBgPm0gmY3Q
   */
   textContent.items.forEach(item => {
     const text = item.str;

--- a/server/src/output/json/JsonExporter.ts
+++ b/server/src/output/json/JsonExporter.ts
@@ -72,6 +72,7 @@ export class JsonExporter extends Exporter {
 
     this.json.pages = this.doc.pages.map((page: Page) => {
       const jsonPage: JsonPage = {
+        margins: this.doc.margins,
         box: this.boxToJsonBox(page.box),
         rotation: this.rotationToJsonRotation(page.pageRotation),
         pageNumber: page.pageNumber,

--- a/server/src/types/DocumentRepresentation/JsonExport.ts
+++ b/server/src/types/DocumentRepresentation/JsonExport.ts
@@ -39,6 +39,12 @@ export interface JsonPage {
   rotation?: JsonPageRotation;
   pageNumber: number;
   elements: JsonElement[];
+  margins: {
+    top: number,
+    left: number,
+    bottom: number,
+    right: number,
+  };
 }
 
 export interface JsonBox {


### PR DESCRIPTION
Added page margins visualization in the VUE GUI :
<img width="618" alt="Screenshot 2020-01-07 at 18 10 18" src="https://user-images.githubusercontent.com/11478307/71914033-fdac8580-3178-11ea-969f-c1af221d247b.png">

This will ease the debugging of margins-related bugs like the one in this story:
https://app.clubhouse.io/parsr/story/3482/header-footer-detection
