### PR TITLE
[header-footer-detection] - separated responsibilities from HeaderFoo…

### DIFF
--- a/demo/jupyter-notebook/sampleConfig.json
+++ b/demo/jupyter-notebook/sampleConfig.json
@@ -62,13 +62,7 @@
     ],
     "heading-detection",
     "list-detection",
-    [
-      "page-number-detection",
-      {
-        "ignorePages": [],
-        "maxMarginPercentage": 15
-      }
-    ],
+    "page-number-detection",
     "hierarchy-detection",
     [
       "regex-matcher",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,7 +154,7 @@ The `includeMarginals: boolean` parameter allows to chose whether the output wil
     "link-detection",
     ["words-to-line", { "maximumSpaceBetweenWords": 100 }],
     "lines-to-paragraph",
-    ["page-number-detection", { "maxMarginPercentage": 15 }],
+    "page-number-detection",
     "hierarchy-detection",
     [
       "regex-matcher",

--- a/server/configKeyValueSearch.json
+++ b/server/configKeyValueSearch.json
@@ -15,7 +15,7 @@
 		"link-detection",
 		["words-to-line", { "maximumSpaceBetweenWords": 100 }],
 		"lines-to-paragraph",
-		["page-number-detection", { "maxMarginPercentage": 15 }],
+		"page-number-detection",
 		"hierarchy-detection",
 		[
 			"key-value-detection",

--- a/server/defaultConfig.json
+++ b/server/defaultConfig.json
@@ -63,13 +63,7 @@
     "heading-detection",
     "heading-detection-dt",
     "list-detection",
-    [
-      "page-number-detection",
-      {
-        "ignorePages": [],
-        "maxMarginPercentage": 15
-      }
-    ],
+    "page-number-detection",
     "hierarchy-detection",
     [
       "regex-matcher",

--- a/server/src/input/pdf.js/pdfjs.ts
+++ b/server/src/input/pdf.js/pdfjs.ts
@@ -86,8 +86,10 @@ async function loadPage(document: any, pageNum: number): Promise<Page> {
       - calculate each single word's BBox,
       - search for splitted words to join them together
 
-      MAtrix reference on page 142 of PDF doc https://via.hypothes.is/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf#annotations:SVudloF5EemLBgPm0gmY3Q
-  */
+      MAtrix reference on page 142 of PDF doc
+      https://via.hypothes.is/https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/
+      PDFReference.pdf#annotations:SVudloF5EemLBgPm0gmY3Q
+      */
   textContent.items.forEach(item => {
     const text = item.str;
     if (text.length > 0) {

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -18,8 +18,6 @@ import {
   BoundingBox,
   Document,
   Element,
-  Paragraph,
-  Text,
 } from '../../types/DocumentRepresentation';
 import * as utils from '../../utils';
 import logger from '../../utils/Logger';
@@ -164,39 +162,13 @@ export class HeaderFooterDetectionModule extends Module<Options> {
 
       for (const element of footerElements) {
         element.properties.isFooter = true;
-        if (element instanceof Paragraph && isPageNumber(element)) {
-          element.properties.isPageNumber = true;
-        }
       }
 
       for (const element of headerElements) {
         element.properties.isHeader = true;
-        if (element instanceof Paragraph && isPageNumber(element)) {
-          element.properties.isPageNumber = true;
-        }
       }
     });
     logger.debug('Done with marginals detection.');
     return doc;
-
-    /**
-     * Checks if a text is a page number using a regexp matching.
-     * @param text The text entity in question
-     */
-    function isPageNumber(text: Text): boolean {
-      const match = text.toString().match(utils.getPageRegex());
-      let pageNumber: string;
-      if (!match) {
-        return false;
-      }
-
-      for (let i = 1; i < match.length; i++) {
-        if (match[i]) {
-          pageNumber = match[i];
-        }
-      }
-
-      return pageNumber && pageNumber !== '';
-    }
   }
 }

--- a/server/src/processing/PageNumberDetectionModule/defaultConfig.json
+++ b/server/src/processing/PageNumberDetectionModule/defaultConfig.json
@@ -1,16 +1,4 @@
 {
 	"name": "page-number-detection",
-	"description": "Detects the page number for each page in a document",
-	"specs": {
-		"ignorePages": {
-			"value": []
-		},
-		"maxMarginPercentage": {
-			"value": 30,
-			"range": {
-				"min": 0,
-				"max": 100
-			}
-		}
-	}
+	"description": "Detects the page number for each page in a document"
 }


### PR DESCRIPTION
- separated responsibilities from HeaderFooterDetection and PageNumberDetection modules
- removed all optional parameters from PageNumberDetectionModule

now PageNumberDetectionModule only detects 'page number' texts using the previously calculated margins from HeaderFooterDetectionModule

this is related to https://app.clubhouse.io/parsr/story/3482/header-footer-detection