### PR TITLE
Omits input filename extension in the outputted filenames

### DIFF
--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -143,7 +143,7 @@ function main(): void {
         if (config.output.formats.json) {
           promises.push(
             new JsonExporter(doc, config.output.granularity).export(
-              `${outputFolder}/${documentName}.json`,
+              `${outputFolder}/${omitFilenameExtension(documentName)}.json`,
             ),
           );
         }
@@ -151,7 +151,7 @@ function main(): void {
         // if (config.output.formats['json-compact']) {
         // 	promises.push(
         // 		new JsonCompactExporter(doc).export(
-        // 			`${outputFolder}/${documentName}.compact.json`,
+        // 			`${outputFolder}/${getBaseFilename(documentName)}.compact.json`,
         // 		),
         // 	);
         // }
@@ -159,7 +159,7 @@ function main(): void {
         if (config.output.formats.text) {
           promises.push(
             new TextExporter(doc, config.output.includeMarginals).export(
-              `${outputFolder}/${documentName}.txt`,
+              `${outputFolder}/${omitFilenameExtension(documentName)}.txt`,
             ),
           );
         }
@@ -167,7 +167,7 @@ function main(): void {
         if (config.output.formats.markdown) {
           promises.push(
             new MarkdownExporter(doc, config.output.includeMarginals).export(
-              `${outputFolder}/${documentName}.md`,
+              `${outputFolder}/${omitFilenameExtension(documentName)}.md`,
             ),
           );
         }
@@ -175,7 +175,7 @@ function main(): void {
         // if (config.output.formats.xml) {
         // 	promises.push(
         // 		new XmlExporter(doc).export(
-        // 			`${outputFolder}/${documentName}.md`
+        // 			`${outputFolder}/${getBaseFilename(documentName)}.md`
         // 		)
         // 	);
         // }
@@ -183,21 +183,25 @@ function main(): void {
         // if (config.output.formats.confidences) {
         // 	promises.push(
         // 		new ConfidencesExporter(doc).export(
-        // 			`${outputFolder}/${documentName}.confidences`
+        // 			`${outputFolder}/${getBaseFilename(documentName)}.confidences`
         // 		)
         // 	);
         // }
 
         if (config.output.formats.csv) {
-          promises.push(new CsvExporter(doc).export(`${outputFolder}/${documentName}.csv`));
+          promises.push(new CsvExporter(doc).export(`${outputFolder}/${omitFilenameExtension(documentName)}.csv`));
         }
 
         if (config.output.formats.pdf) {
           promises.push(
             new PdfExporter(doc, config.output.includeMarginals).export(
-              `${outputFolder}/${documentName}.pdf`,
+              `${outputFolder}/${omitFilenameExtension(documentName)}.pdf`,
             ),
           );
+        }
+
+        function omitFilenameExtension(filename: string): string {
+          return filename.replace(/\.[^/.]+$/, "");
         }
 
         logger.debug('Done');

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -151,7 +151,7 @@ function main(): void {
         // if (config.output.formats['json-compact']) {
         // 	promises.push(
         // 		new JsonCompactExporter(doc).export(
-        // 			`${outputFolder}/${getBaseFilename(documentName)}.compact.json`,
+        // 			`${outputFolder}/${omitFilenameExtension(documentName)}.compact.json`,
         // 		),
         // 	);
         // }
@@ -175,7 +175,7 @@ function main(): void {
         // if (config.output.formats.xml) {
         // 	promises.push(
         // 		new XmlExporter(doc).export(
-        // 			`${outputFolder}/${getBaseFilename(documentName)}.md`
+        // 			`${outputFolder}/${omitFilenameExtension(documentName)}.md`
         // 		)
         // 	);
         // }
@@ -183,7 +183,7 @@ function main(): void {
         // if (config.output.formats.confidences) {
         // 	promises.push(
         // 		new ConfidencesExporter(doc).export(
-        // 			`${outputFolder}/${getBaseFilename(documentName)}.confidences`
+        // 			`${outputFolder}/${omitFilenameExtension(documentName)}.confidences`
         // 		)
         // 	);
         // }


### PR DESCRIPTION
Leaves out the .pdf mention from the outputted results' filenames.
Example: Converts 'results.pdf.md' to 'results.md' for the initial file 'results.pdf'.