### PR TITLE
Fix / .eml tmp files

### DIFF
--- a/server/src/input/email/EmailExtractor.ts
+++ b/server/src/input/email/EmailExtractor.ts
@@ -94,7 +94,7 @@ export class EmailExtractor extends Extractor {
       ].filter(f => !!f);
 
       const files = await Promise.all(pdfFilesToJoin);
-      const fullPDF = inputFile.replace('.eml', '.pdf');
+      const fullPDF = inputFile.replace('.eml', '-tmp.pdf');
       await mergePDFs(files, fullPDF);
       return fullPDF;
     } catch (e) {


### PR DESCRIPTION
renamed temporal PDF file used by EmailExtractor. This files are deleted after being generated by the tests