### PR TITLE
[google-vision] - added image extraction options to the UI

### DIFF
--- a/api/server/src/ProcessManager.ts
+++ b/api/server/src/ProcessManager.ts
@@ -28,10 +28,16 @@ export class ProcessManager {
     config: string,
     docName: string,
     outputPath: string,
+    credentials: {
+      googleVision: string,
+    },
   ): void {
     logger.info('Processing ' + doc);
 
     process.env.NODE_DEBUG = 'pipeline';
+    if (credentials.googleVision) {
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = credentials.googleVision;
+    }
 
     const args: string[] = [
       `../../dist/bin/index.js`,

--- a/api/server/src/api.ts
+++ b/api/server/src/api.ts
@@ -77,6 +77,7 @@ export class ApiServer {
     const uploadsConf: multer.Field[] = [
       { name: 'file', maxCount: 1 },
       { name: 'config', maxCount: 1 },
+      { name: 'gvCredentials', maxCount: 1 },
     ];
 
     v1_0.post('/document', this.upload.fields(uploadsConf), this.handlePostDoc.bind(this));
@@ -333,8 +334,12 @@ export class ApiServer {
       return;
     }
 
+    const credentials = {
+      googleVision: 'gvCredentials' in req.files && req.files.gvCredentials[0].path,
+    };
+
     this.fileManager.newBinder(docId, doc.path, config.path, outputPath, docName);
-    this.processManager.start(doc.path, docId, config.path, docName, outputPath);
+    this.processManager.start(doc.path, docId, config.path, docName, outputPath, credentials);
 
     res
       .status(202)

--- a/demo/vue-viewer/src/components/UploadConfig/ConfigItem.vue
+++ b/demo/vue-viewer/src/components/UploadConfig/ConfigItem.vue
@@ -171,7 +171,7 @@ export default {
 }
 .switch div.v-expansion-panels {
   margin-left: 40px;
-  width: 273px;
+  width: 267px;
 }
 .switch div.v-expansion-panels button.v-expansion-panel-header {
   padding: 0;

--- a/demo/vue-viewer/src/services/DocumentServices.js
+++ b/demo/vue-viewer/src/services/DocumentServices.js
@@ -69,10 +69,11 @@ export default {
   getDocumentCsv(url) {
     return apiClient.get(url.replace('/api/v1', ''));
   },
-  postDocument(file, configuration) {
+  postDocument(file, configuration, credentials) {
     const formData = new FormData();
     formData.append('file', file, file.name);
     formData.append('config', configuration);
+    formData.append('gvCredentials', credentials.googleVision);
     return apiClient.post('/document', formData);
   },
   getDocumentStatus(docID) {

--- a/demo/vue-viewer/src/views/Upload.vue
+++ b/demo/vue-viewer/src/views/Upload.vue
@@ -3,13 +3,7 @@
     <form @submit.prevent="upload">
       <fieldset>
         <legend>Input file</legend>
-        <input
-          type="file"
-          id="file"
-          name="file"
-          @change="fileChanged($event)"
-          style="margin:10px 0px"
-        />
+        <input type="file" id="file" name="file" @change="fileChanged" style="margin:10px 0px" />
       </fieldset>
 
       <fieldset>
@@ -26,6 +20,28 @@
           prefix="Pdf"
           solo
         ></v-select>
+        <v-select
+          :items="['tesseract', 'abbyy', 'google-vision']"
+          v-model="defaultConfig.extractor.img"
+          :flat="true"
+          :hide-details="true"
+          background-color="transparent"
+          color="rgba(0, 0, 0, 0.54)"
+          height="20px"
+          class="selectOptionExtractor"
+          prefix="Images"
+          solo
+        ></v-select>
+        <div style="padding-left: 60px" class="selectOptionExtractor" v-if="defaultConfig.extractor.img === 'google-vision'">
+          <legend><sup>*</sup>GOOGLE_APPLICATION_CREDENTIALS:</legend>
+          <input
+            type="file"
+            @change="googleCredentialsChanged"
+            id="googleVisionCredentials"
+            name="googleVisionCredentials"
+            accept="application/json"
+          />
+        </div>
       </fieldset>
 
       <fieldset>
@@ -77,6 +93,7 @@ export default {
       items: [true, false],
       checkIcon: CheckIcon,
       file: null,
+      gvCredentials: null,
       loading: false,
       processStatus: [],
       processStatusCompleted: false,
@@ -99,9 +116,11 @@ export default {
       });
     },
     isSubmitDisabled() {
-      return !this.file;
+      return (
+        !this.file || (this.customConfig.extractor.img === 'google-vision' && !this.gvCredentials)
+      );
     },
-    /* 
+    /*
 			this function takes the config in 'specs' format and returns only the values of each parameter
 			ex:
 				parameter: {
@@ -166,6 +185,9 @@ export default {
     fileChanged(event) {
       this.file = event.target.files[0];
     },
+    googleCredentialsChanged(event) {
+      this.gvCredentials = event.target.files[0];
+    },
     trackPipeStatus() {
       const interval = setInterval(() => {
         this.$store
@@ -205,6 +227,9 @@ export default {
         .dispatch('postDocument', {
           file: this.file,
           configuration: this.configAsBinary,
+          credentials: {
+            googleVision: this.gvCredentials,
+          },
         })
         .then(() => {
           this.processStatus = ['Upload Completed'];
@@ -244,7 +269,7 @@ export default {
   padding: 0 !important;
 }
 .selectOptionExtractor div.v-input__control div.v-select__slot {
-  width: 100px;
+  width: 210px;
 }
 .selectOptionExtractor div.v-input__control div.v-select__slot div.v-text-field__prefix {
   min-width: 60px;
@@ -252,7 +277,7 @@ export default {
 }
 .selectOptionExtractor div.v-input__control div.v-input__slot div.v-select__selection {
   border: solid 1px #cccccc;
-  min-width: 90px;
+  min-width: 120px;
   text-align: center;
   display: block;
   padding: 0 5px;

--- a/demo/vue-viewer/src/views/Upload.vue
+++ b/demo/vue-viewer/src/views/Upload.vue
@@ -32,7 +32,11 @@
           prefix="Images"
           solo
         ></v-select>
-        <div style="padding-left: 60px" class="selectOptionExtractor" v-if="defaultConfig.extractor.img === 'google-vision'">
+        <div
+          style="padding-left: 60px"
+          class="selectOptionExtractor"
+          v-if="defaultConfig.extractor.img === 'google-vision'"
+        >
           <legend><sup>*</sup>GOOGLE_APPLICATION_CREDENTIALS:</legend>
           <input
             type="file"

--- a/demo/vue-viewer/src/vuex/store.js
+++ b/demo/vue-viewer/src/vuex/store.js
@@ -247,8 +247,8 @@ export default new Vuex.Store({
           throw error;
         });
     },
-    postDocument({ commit }, { file, configuration }) {
-      return DocumentService.postDocument(file, configuration).then(response => {
+    postDocument({ commit }, { file, configuration, credentials }) {
+      return DocumentService.postDocument(file, configuration, credentials).then(response => {
         commit('SET_DOCUMENT_ID', response.data);
         commit('SET_DOCUMENT', null);
         commit('SET_DOCUMENT_TEXT', null);

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -129,8 +129,7 @@ function main(): void {
           logger.info(
             `Since the input file is a PDF with only images, trying to run an OCR on all pages...`,
           );
-          orchestrator = getImgExtractor();
-          return orchestrator.run(filePath);
+          return getImgExtractor().run(filePath);
         }
         return doc;
       })

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -129,11 +129,7 @@ function main(): void {
           logger.info(
             `Since the input file is a PDF with only images, trying to run an OCR on all pages...`,
           );
-          if (config.extractor.img === 'tesseract') {
-            orchestrator = new Orchestrator(new TesseractExtractor(config), cleaner);
-          } else {
-            orchestrator = new Orchestrator(new AbbyyTools(config), cleaner);
-          }
+          orchestrator = getImgExtractor();
           return orchestrator.run(filePath);
         }
         return doc;

--- a/server/src/input/OcrExtractor.ts
+++ b/server/src/input/OcrExtractor.ts
@@ -1,0 +1,90 @@
+import * as filetype from 'file-type';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Document } from '../types/DocumentRepresentation/Document';
+import { CommandExecuter, pdfToImages } from '../utils';
+import logger from '../utils/Logger';
+import { Extractor } from './Extractor';
+
+export abstract class OcrExtractor extends Extractor {
+  public abstract async ocrPDF(inputFile: string, fixRotation: boolean);
+  public abstract ocrImages(pages: string[], fixRotation: boolean): Promise<Document>;
+  public abstract ocrImage(page: string, fixRotation: boolean): Promise<Document>;
+  public abstract isPdfFile(filePath: string): boolean;
+}
+
+export type RotationCorrectionCoords = {
+  x: number;
+  y: number;
+};
+
+export type RotationCorrection = {
+  fileName: string;
+  degrees: number;
+  origin: RotationCorrectionCoords;
+  translation: RotationCorrectionCoords;
+};
+
+// tslint:disable-next-line: max-classes-per-file
+export class OcrExtractorFactory extends OcrExtractor {
+  public async ocrPDF(inputFile: string, fixRotation: boolean) {
+    const imagePaths = await pdfToImages(inputFile);
+    return this.ocrImages(imagePaths, fixRotation).then((doc: Document) => {
+      doc.inputFile = inputFile;
+      return doc;
+    });
+  }
+
+  public ocrImages(
+    pages: string[],
+    fixRotation: boolean,
+    allPagesDoc: Document = new Document([]),
+    index: number = 0,
+  ): Promise<Document> {
+    return this.ocrImage(pages[index], fixRotation).then((doc: Document) => {
+      allPagesDoc.pages = allPagesDoc.pages.concat(doc.pages);
+      allPagesDoc.pages[index].pageNumber = index + 1;
+      if (pages.length > index + 1) {
+        return this.ocrImages(pages, fixRotation, allPagesDoc, index + 1);
+      } else {
+        return allPagesDoc;
+      }
+    });
+  }
+
+  public isPdfFile(filePath: string): boolean {
+    const fileType: { ext: string; mime: string } = filetype(fs.readFileSync(filePath));
+    return fileType !== null && fileType.ext.toLowerCase() === 'pdf';
+  }
+
+  public run(_inputFile: string): Promise<Document> {
+    throw new Error('Method not implemented.');
+  }
+
+  public ocrImage(_page: string, _fixRotation: boolean): Promise<Document> {
+    throw new Error('Method not implemented.');
+  }
+
+  protected async correctImageForRotation(srcImg: string): Promise<RotationCorrection> {
+    const correctionInfo: RotationCorrection = {
+      fileName: srcImg,
+      degrees: 0,
+      origin: { x: 0, y: 0 },
+      translation: { x: 0, y: 0 },
+    };
+
+    const args: string[] = [path.join(__dirname, '../../assets/ImageCorrection.py'), srcImg];
+    try {
+      const data = await CommandExecuter.run(CommandExecuter.COMMANDS.PYTHON, args);
+      const rotationData = JSON.parse(data);
+      correctionInfo.fileName = rotationData.filename;
+      correctionInfo.degrees = rotationData.degrees;
+      correctionInfo.origin = rotationData.origin;
+      correctionInfo.translation = rotationData.translation;
+    } catch ({ error }) {
+      logger.error(error);
+      logger.warn(`Error running image rotation calculation.. using the original image.`);
+    }
+    return correctionInfo;
+  }
+}

--- a/server/src/input/google-vision/GoogleVisionExtractor.ts
+++ b/server/src/input/google-vision/GoogleVisionExtractor.ts
@@ -196,7 +196,7 @@ export class GoogleVisionExtractor extends Extractor {
       pages.push(page);
     });
 
-    const doc: Document = new Document(pages);
+    const doc: Document = new Document(pages, inputFile);
 
     return doc;
   }

--- a/server/src/input/tesseract/TesseractExtractor.ts
+++ b/server/src/input/tesseract/TesseractExtractor.ts
@@ -15,48 +15,43 @@
  */
 
 import { Document } from '../../types/DocumentRepresentation';
-import { pdfToImages } from '../../utils';
-import { Extractor } from '../Extractor';
+import { OcrExtractorFactory } from '../OcrExtractor';
 import { setPageDimensions } from '../set-page-dimensions';
 import * as tesseract2json from './tesseract2json';
 
 /**
  * An extractor class to extract content from images using the tesseract OCR extraction tool.
  */
-export class TesseractExtractor extends Extractor {
+export class TesseractExtractor extends OcrExtractorFactory {
   /**
    * Runs the extraction process, first setting page dimensions, then extracting the document itself.
    * @param inputFile The name of the image to be used at input for the extraction.
    * @returns The promise of a valid Document (as per the Document Representation namespace).
    */
   public async run(inputFile: string, rotationCorrection: boolean = true): Promise<Document> {
-    const imagePaths = await pdfToImages(inputFile);
-    return this.scanPages(imagePaths, rotationCorrection).then((doc: Document) => {
+    if (this.isPdfFile(inputFile)) {
+      return this.ocrPDF(inputFile, rotationCorrection);
+    }
+    return this.scanImage(inputFile);
+  }
+
+  public async ocrImage(inputFile: string, fixRotation: boolean): Promise<Document> {
+    let rotationCorrection = null;
+    const orignalInput = inputFile;
+    if (fixRotation) {
+      rotationCorrection = await this.correctImageForRotation(inputFile);
+      inputFile = rotationCorrection.fileName;
+    }
+
+    return tesseract2json
+      .execute(inputFile, rotationCorrection, this.config)
+      .then((doc: Document) => setPageDimensions(doc, orignalInput));
+  }
+
+  private async scanImage(inputFile: string, fixRotation: boolean = true) {
+    return this.ocrImages([inputFile], fixRotation).then((doc: Document) => {
       doc.inputFile = inputFile;
       return doc;
-    });
-  }
-
-  private scanPage(page: string, fixRotation: boolean): Promise<Document> {
-    return tesseract2json
-      .execute(page, fixRotation, this.config)
-      .then((doc: Document) => setPageDimensions(doc, page));
-  }
-
-  private scanPages(
-    pages: string[],
-    fixRotation: boolean,
-    allPagesDoc: Document = new Document([]),
-    index: number = 0,
-  ): Promise<Document> {
-    return this.scanPage(pages[index], fixRotation).then((doc: Document) => {
-      allPagesDoc.pages = allPagesDoc.pages.concat(doc.pages);
-      allPagesDoc.pages[index].pageNumber = index + 1;
-      if (pages.length > index + 1) {
-        return this.scanPages(pages, fixRotation, allPagesDoc, index + 1);
-      } else {
-        return allPagesDoc;
-      }
     });
   }
 }

--- a/server/src/input/tesseract/tesseract2json.ts
+++ b/server/src/input/tesseract/tesseract2json.ts
@@ -20,6 +20,7 @@ import { BoundingBox, Document, Font, Page, Word } from '../../types/DocumentRep
 import { TsvElement } from '../../types/TsvElement';
 import * as utils from '../../utils';
 import logger from '../../utils/Logger';
+import { RotationCorrection } from '../OcrExtractor';
 
 /**
  * Executes the tesseract to json conversion module, which entails calling
@@ -29,7 +30,7 @@ import logger from '../../utils/Logger';
  */
 export function execute(
   imageInputFile: string,
-  fixRotation: boolean,
+  rotationCorrection: RotationCorrection,
   config: Config,
 ): Promise<Document> {
   return new Promise<Document>(async (resolve, reject) => {
@@ -74,13 +75,6 @@ export function execute(
     }
 
     const tesseractLanguages = validLanguages.map(lang => lang.trim()).join('+');
-
-    // correct for the rotation in the image
-    let rotationCorrection = null;
-    if (fixRotation) {
-      rotationCorrection = await utils.correctImageForRotation(imageInputFile);
-      imageInputFile = rotationCorrection.fileName;
-    }
 
     /**
      * From man page

--- a/server/src/output/json/JsonExporter.ts
+++ b/server/src/output/json/JsonExporter.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { RotationCorrection } from '../../input/OcrExtractor';
 import {
   Barcode,
   BoundingBox,
@@ -282,7 +283,7 @@ export class JsonExporter extends Exporter {
     return jsonBox;
   }
 
-  private rotationToJsonRotation(rotation: utils.RotationCorrection): JsonPageRotation {
+  private rotationToJsonRotation(rotation: RotationCorrection): JsonPageRotation {
     if (rotation != null) {
       const jsonRotation: JsonPageRotation = {
         degrees: rotation.degrees,

--- a/server/src/types/DocumentRepresentation/Page.ts
+++ b/server/src/types/DocumentRepresentation/Page.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { findMostCommonFont, isInBox, RotationCorrection } from '../../utils';
+import { RotationCorrection } from '../../input/OcrExtractor';
+import { findMostCommonFont, isInBox } from '../../utils';
 import logger from '../../utils/Logger';
 import { BoundingBox } from './BoundingBox';
 import { Element } from './Element';

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -239,7 +239,7 @@ export function pdfToImages(pdfPath: string): Promise<string[]> {
     ])
       .then(() => {
         const files = fs.readdirSync(folder).map(file => path.join(folder, file));
-        logger.info(`converted files: ${files.join(', ')}`);
+        logger.info(`Sample files: ${files.join('\n')}`);
         resolve(files);
       })
       .catch(({ found, error }) => {
@@ -252,44 +252,6 @@ export function pdfToImages(pdfPath: string): Promise<string[]> {
         reject(error);
       });
   });
-}
-/**
- * Applies rotation correction given an input image and returns RotationCorrection
- * @param srcImg source image
- */
-
-export type RotationCorrectionCoords = {
-  x: number;
-  y: number;
-};
-export type RotationCorrection = {
-  fileName: string;
-  degrees: number;
-  origin: RotationCorrectionCoords;
-  translation: RotationCorrectionCoords;
-};
-
-export async function correctImageForRotation(srcImg: string): Promise<RotationCorrection> {
-  const correctionInfo: RotationCorrection = {
-    fileName: srcImg,
-    degrees: 0,
-    origin: { x: 0, y: 0 },
-    translation: { x: 0, y: 0 },
-  };
-
-  const args: string[] = [path.join(__dirname, '../assets/ImageCorrection.py'), srcImg];
-  try {
-    const data = await CommandExecuter.run(CommandExecuter.COMMANDS.PYTHON, args);
-    const rotationData = JSON.parse(data);
-    correctionInfo.fileName = rotationData.filename;
-    correctionInfo.degrees = rotationData.degrees;
-    correctionInfo.origin = rotationData.origin;
-    correctionInfo.translation = rotationData.translation;
-  } catch ({ error }) {
-    logger.error(error);
-    logger.warn(`Error running image rotation calculation.. using the original image.`);
-  }
-  return correctionInfo;
 }
 
 /**

--- a/test/number-digits-preservation.spec.ts
+++ b/test/number-digits-preservation.spec.ts
@@ -38,7 +38,7 @@ describe('Number parsing on images', () => {
   });
 
   it('should preserve all digits in a number', () => {
-    expect(words).to.eql(expectedWords);
+    expect(words.filter(w => w !== '').sort()).to.eql(expectedWords.sort());
   });
 });
 
@@ -57,6 +57,6 @@ describe('Number parsing on PDFs', () => {
   });
 
   it('should preserve all digits in a number', () => {
-    expect(words).to.eql(expectedWords);
+    expect(words.filter(w => w !== '').sort()).to.eql(expectedWords.sort());
   });
 });


### PR DESCRIPTION
- added tesseract, abbyy and google-vision options for image extraction in the UI
- if google-vision is selected, an aditional file is required: the Google credentials JSON file.
  This credentials can be generated for free in Google Cloud Platform, and an enabled billing account is required.
- if google-vision is executed via CLI, it's required to set an environment variable before calling the tool: `GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/file.json`

<img width="629" alt="Screenshot 2020-01-14 at 16 35 50" src="https://user-images.githubusercontent.com/11478307/72357843-f1ca4180-36eb-11ea-900d-d7ee664b9c5a.png">

https://app.clubhouse.io/parsr/story/4492/new-ocr-google

- also, a minor cosmetic bug is fixed in this PR: https://app.clubhouse.io/parsr/story/4526/cosmetic-issue-with-the-arrow-on-the-ui


 **TODO**: add more input formats for Google Vision (only images supported for now)