### PR TITLE
[fix/camelot] - edited camelot installation command

### DIFF
--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -16,8 +16,8 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 
 RUN apt-get update && \
     apt-get install -y imagemagick graphicsmagick mupdf mupdf-tools qpdf pandoc tesseract-ocr-all nodejs npm python-pdfminer python-pip python3-pip python-tk python3-pdfminer python3-opencv && \
-    pip install ghostscript camelot-py scikit-image numpy pillow && \
-    pip3 install ghostscript camelot-py scikit-image numpy pillow
+    pip install ghostscript camelot-py[cv] scikit-image numpy pillow && \
+    pip3 install ghostscript camelot-py[cv] scikit-image numpy pillow
     
 WORKDIR /opt/app-root/src
 RUN chown 1001:0 /opt/app-root/src

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ Under a **Debian** based distribution:
 sudo add-apt-repository ppa:ubuntuhandbook1/apps
 sudo apt-get update
 sudo apt-get install nodejs npm qpdf imagemagick graphicsmagick tesseract-ocr libtesseract-dev python3-tk ghostscript python3-pip
-pip install camelot-py
+pip install camelot-py[cv]
 pip install numpy pillow scikit-image
 pip install pdfminer.six
 ```
@@ -41,7 +41,7 @@ Under **Arch** Linux :
 
 ```sh
 pacman -S nodejs npm qpdf imagemagick graphicsmagick pdfminer tesseract python-pip
-pip install camelot-py
+pip install camelot-py[cv]
 pip install numpy pillow scikit-image
 ```
 
@@ -71,7 +71,7 @@ and then the dependencies:
 
 ```sh
 pip install pdfminer.six
-pip install camelot-py
+pip install camelot-py[cv]
 pip install numpy pillow scikit-image
 ```
 


### PR DESCRIPTION
changed `pip install camelot-py` to `pip install camelot-py[cv]` as it is the recommended way to install camelot and it adds a required package for Parsr to work fine with table detection: opencv-python