### PR TITLE
Install/macos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -687,8 +687,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "resolved": "",
           "dev": true
         }
       }
@@ -1637,9 +1636,9 @@
           }
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -2041,8 +2040,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "resolved": "",
           "dev": true
         }
       }
@@ -3779,9 +3777,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -3978,9 +3976,9 @@
       },
       "dependencies": {
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -5263,8 +5261,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "resolved": "",
           "dev": true
         }
       }

--- a/preinstall-scripts/darwin.bash.sh
+++ b/preinstall-scripts/darwin.bash.sh
@@ -1,0 +1,11 @@
+#!/bin/bash 
+
+tmp_dir=$(mktemp -d -t parsr-install) 
+
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" &&
+sh $tmp_dir/brew-install.sh &&
+brew install node qpdf imagemagick tesseract tesseract-lang tcl-tk ghostscript mupdf-tools pandoc &&
+curl https://bootstrap.pypa.io/get-pip.py -o $tmp_dir/get-pip.py &&
+python $tmp_dir/get-pip.py &&
+pip install pdfminer.six camelot-py[cv] &&
+rm -rf $tmp_dir

--- a/preinstall-scripts/darwin.bash.sh
+++ b/preinstall-scripts/darwin.bash.sh
@@ -3,7 +3,6 @@
 tmp_dir=$(mktemp -d -t parsr-install) 
 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" &&
-sh $tmp_dir/brew-install.sh &&
 brew install node qpdf imagemagick tesseract tesseract-lang tcl-tk ghostscript mupdf-tools pandoc &&
 curl https://bootstrap.pypa.io/get-pip.py -o $tmp_dir/get-pip.py &&
 python $tmp_dir/get-pip.py &&

--- a/preinstall-scripts/darwin.bash.sh
+++ b/preinstall-scripts/darwin.bash.sh
@@ -3,7 +3,7 @@
 tmp_dir=$(mktemp -d -t parsr-install) 
 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" &&
-brew install node qpdf imagemagick tesseract tesseract-lang tcl-tk ghostscript mupdf-tools pandoc &&
+brew install qpdf imagemagick tesseract tesseract-lang tcl-tk ghostscript mupdf-tools pandoc &&
 curl https://bootstrap.pypa.io/get-pip.py -o $tmp_dir/get-pip.py &&
 python $tmp_dir/get-pip.py &&
 pip install pdfminer.six camelot-py[cv] &&

--- a/preinstall-scripts/darwin.commands.js
+++ b/preinstall-scripts/darwin.commands.js
@@ -1,13 +1,3 @@
-const { tmpdir } = require('os');
-const tmp = tmpdir();
+const { join } = require('path');
 
-const commands = [
-  `curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh -o ${tmp}/brew-install.sh`,
-  `sh ${tmp}/brew-install.sh`,
-  'brew install node qpdf imagemagick tesseract tesseract-lang tcl-tk ghostscript mupdf-tools pandoc',
-  `curl https://bootstrap.pypa.io/get-pip.py -o ${tmp}/get-pip.py`,
-  `python ${tmp}/get-pip.py`,
-  'pip install pdfminer.six camelot-py[cv]',
-];
-
-module.exports = ['/bin/bash', '-c', `"$(${commands.join(';')})"`];
+module.exports = ['/bin/bash', '-c', join(__dirname, '/darwin.bash.sh')];

--- a/preinstall-scripts/darwin.commands.js
+++ b/preinstall-scripts/darwin.commands.js
@@ -1,3 +1,3 @@
 const { join } = require('path');
 
-module.exports = ['/bin/bash', '-c', join(__dirname, '/darwin.bash.sh')];
+module.exports = ['/bin/bash', '-c', join(__dirname, 'darwin.bash.sh')];

--- a/preinstall-scripts/darwin.commands.js
+++ b/preinstall-scripts/darwin.commands.js
@@ -1,0 +1,13 @@
+const { tmpdir } = require('os');
+const tmp = tmpdir();
+
+const commands = [
+  `curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh -o ${tmp}/brew-install.sh`,
+  `sh ${tmp}/brew-install.sh`,
+  'brew install node qpdf imagemagick tesseract tesseract-lang tcl-tk ghostscript mupdf-tools pandoc',
+  `curl https://bootstrap.pypa.io/get-pip.py -o ${tmp}/get-pip.py`,
+  `python ${tmp}/get-pip.py`,
+  'pip install pdfminer.six camelot-py[cv]',
+];
+
+module.exports = ['/bin/bash', '-c', `"$(${commands.join(';')})"`];

--- a/preinstall-scripts/index.js
+++ b/preinstall-scripts/index.js
@@ -8,7 +8,7 @@ const commands = {
 
 function promisifySpawn(cmd, args = []) {
   return new Promise((resolve, reject) => {
-    const process = spawn(cmd, args);
+    const process = spawn(cmd, args, { stdio: 'inherit' });
     process.on('close', code => {
       resolve(code);
     });

--- a/preinstall-scripts/index.js
+++ b/preinstall-scripts/index.js
@@ -3,6 +3,7 @@ const { platform } = require('os');
 
 const commands = {
   win32: require('./windows.commands'),
+  darwin: require('./darwin.commands'),
 };
 
 function promisifySpawn(cmd, args = []) {
@@ -13,6 +14,9 @@ function promisifySpawn(cmd, args = []) {
     });
     process.on('error', err => {
       reject(err);
+    });
+    process.on('message', m => {
+      console.log(m.toString());
     });
   });
 }

--- a/preinstall-scripts/windows.commands.js
+++ b/preinstall-scripts/windows.commands.js
@@ -4,7 +4,7 @@ const commands = [
   '[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072',
   "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
   'choco install imagemagick.app -PackageParameters LegacySupport=true -PackageParameters installDevelopmentTools=true -y',
-  'choco install nodejs-lts python ghostscript qpdf pandoc mupdf -y',
+  'choco install python ghostscript qpdf pandoc mupdf -y',
   'choco install tesseract --pre -y',
   'curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py',
   "[System.Environment]::SetEnvironmentVariable('Path', [System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path','User')); refreshenv",


### PR DESCRIPTION
Automatic installation script for macOS platforms.

- removed `brew install node` and `choco install nodejs-lts`, because this can lead to problems if node was installed via nvm. Also, node is a prerequisite for this script so it's not necessary to reinstall it.