### PR TITLE
fix mutool and .pam image files

### DIFF
--- a/server/src/utils/CommandExecuter.ts
+++ b/server/src/utils/CommandExecuter.ts
@@ -104,7 +104,7 @@ export async function repairPdf(filePath: string): Promise<string> {
 
 export async function mutoolExtract(filePath: string): Promise<string> {
   const outputFolder = getMutoolExtractionFolder();
-  return run(COMMANDS.MUTOOL, ['extract', filePath], {
+  return run(COMMANDS.MUTOOL, ['extract', '-r', filePath], {
     cwd: outputFolder,
   }).then(() => {
     logger.info(`Mutool extract succeed --> ${outputFolder}`);


### PR DESCRIPTION
`mutool extract` sometimes extracted images with .pam extension, breaking the copy into assets folder and the rendering on GUI.

this new param tells mutool to extract every image as PNG.
