### PR TITLE
Removed direct usage of GhostScript

### DIFF
--- a/demo/vue-viewer/package-lock.json
+++ b/demo/vue-viewer/package-lock.json
@@ -968,9 +968,9 @@
       "dev": true
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "dev": true
     },
     "@hapi/joi": {
@@ -1772,9 +1772,9 @@
       }
     },
     "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -6491,9 +6491,9 @@
       "dev": true
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "launch-editor": {
       "version": "2.2.1",

--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -16,8 +16,8 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 
 RUN apt-get update && \
     apt-get install -y imagemagick mupdf mupdf-tools qpdf pandoc tesseract-ocr-all nodejs npm python-pdfminer python-pip python3-pip python-tk python3-pdfminer python3-opencv && \
-    pip install ghostscript camelot-py[cv] scikit-image numpy pillow && \
-    pip3 install ghostscript camelot-py[cv] scikit-image numpy pillow
+    pip install ghostscript PyPDF2 camelot-py[cv] scikit-image numpy pillow && \
+    pip3 install ghostscript PyPDF2 camelot-py[cv] scikit-image numpy pillow
     
 WORKDIR /opt/app-root/src
 RUN chown 1001:0 /opt/app-root/src

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,7 @@ sudo add-apt-repository ppa:ubuntuhandbook1/apps
 sudo apt-get update
 sudo apt-get install nodejs npm qpdf imagemagick tesseract-ocr libtesseract-dev python3-tk ghostscript python3-pip
 pip install camelot-py[cv]
-pip install numpy pillow scikit-image
+pip install numpy pillow scikit-image PyPDF2
 pip install pdfminer.six
 ```
 
@@ -54,7 +54,7 @@ Under **Arch** Linux :
 ```sh
 pacman -S nodejs npm qpdf imagemagick pdfminer tesseract python-pip
 pip install camelot-py[cv]
-pip install numpy pillow scikit-image
+pip install numpy pillow scikit-image PyPDF2
 ```
 
 ### 3.2. Installing Dependencies under MacOS
@@ -84,7 +84,7 @@ and then the dependencies:
 ```sh
 pip install pdfminer.six
 pip install camelot-py[cv]
-pip install numpy pillow scikit-image
+pip install numpy pillow scikit-image PyPDF2
 ```
 
 ### 3.3. Installing Dependencies under Windows
@@ -115,6 +115,7 @@ If you have install it in `C:\Program Files (x86)\Tesseract-OCR`, you can either
     ```sh
     setx PATH "\$env:PATH;C:\Program Files (x86)\Tesseract-OCR" -m
     ```
+7. For PDF manipulation, install [PyPDF2](https://pypi.org/project/PyPDF2). *Note: If camelot is installed, PyPDF2 will be already available.*
 
 ## 4. Optional Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parsr",
-  "version": "1.0.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3866,6 +3866,11 @@
         "node-ensure": "^0.0.0",
         "worker-loader": "^2.0.0"
       }
+    },
+    "pdfmerge": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pdfmerge/-/pdfmerge-1.0.2.tgz",
+      "integrity": "sha512-F/8BIE6SpMkPXPLLyamp7cm6AVb5dX0sKbboSAvPVhXzfY3tGT/kFUONaPTQPk2y2UaFzS76y8NU/DHOn6l5kA=="
     },
     "pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "limit-async": "^1.3.0",
     "mailparser": "^2.7.7",
     "pdfjs-dist": "^2.2.228",
+    "pdfmerge": "^1.0.2",
     "pino": "^5.13.2",
     "pino-pretty": "^2.6.1",
     "request": "^2.88.0",

--- a/preinstall-scripts/darwin.bash.sh
+++ b/preinstall-scripts/darwin.bash.sh
@@ -6,5 +6,5 @@ tmp_dir=$(mktemp -d -t parsr-install)
 brew install qpdf imagemagick tesseract tesseract-lang tcl-tk ghostscript mupdf-tools pandoc &&
 curl https://bootstrap.pypa.io/get-pip.py -o $tmp_dir/get-pip.py &&
 python $tmp_dir/get-pip.py &&
-pip install pdfminer.six camelot-py[cv] &&
+pip install pdfminer.six camelot-py[cv] PyPDF2 &&
 rm -rf $tmp_dir

--- a/preinstall-scripts/windows.commands.js
+++ b/preinstall-scripts/windows.commands.js
@@ -9,7 +9,7 @@ const commands = [
   'curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py',
   "[System.Environment]::SetEnvironmentVariable('Path', [System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path','User')); refreshenv",
   'python get-pip.py',
-  'pip install pdfminer.six camelot-py[cv]',
+  'pip install pdfminer.six camelot-py[cv] PyPDF2',
   'npm i --global windows-build-tools'
 ];
 

--- a/server/src/input/email/EmailExtractor.ts
+++ b/server/src/input/email/EmailExtractor.ts
@@ -16,10 +16,11 @@
 
 import { readFileSync, writeFileSync } from 'fs';
 import { simpleParser } from 'mailparser';
+import * as mergePDFs from 'pdfmerge';
 import { Document } from '../../types/DocumentRepresentation';
 import * as CommandExecuter from '../../utils/CommandExecuter';
 import { Extractor } from '../Extractor';
-import { convertHTMLToPDF, getPdfExtractor, getTemporaryFile, mergePDFs } from './../../utils';
+import { convertHTMLToPDF, getPdfExtractor, getTemporaryFile } from './../../utils';
 
 interface MailAttachmentData {
   type: string;
@@ -69,7 +70,7 @@ export class EmailExtractor extends Extractor {
         ...(raw.attachments || []).map(this.attachmentToPDF.bind(this)(raw.html)),
       ].filter(f => !!f);
 
-      const files = await Promise.all(pdfFilesToJoin);
+      const files = (await Promise.all(pdfFilesToJoin)).filter(f => !!f);
       const fullPDF = inputFile.replace('.eml', '-tmp.pdf');
       await mergePDFs(files, fullPDF);
       return fullPDF;

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { exec } from 'child_process';
 import * as concaveman from 'concaveman';
 import HTMLToPDF from 'convert-html-to-pdf';
 import * as crypto from 'crypto';
@@ -37,8 +36,6 @@ import {
   Text,
 } from './types/DocumentRepresentation';
 import logger from './utils/Logger';
-
-import * as CommandExecuter from './utils/CommandExecuter';
 
 import { AbbyyTools } from './input/abbyy/AbbyyTools';
 import { AmazonTextractExtractor } from './input/amazon-textract/AmazonTextractExtractor';
@@ -330,7 +327,7 @@ export function removeNull(page: Page): Page {
   if (page.elements.length - newElements.length !== 0) {
     logger.debug(
       `Null elements removed for page #${page.pageNumber}: ${page.elements.length -
-        newElements.length}`,
+      newElements.length}`,
     );
     page.elements = newElements;
   }
@@ -364,11 +361,11 @@ export function getPageRegex(): RegExp {
 
   const pageRegex = new RegExp(
     `^(?:` +
-      `(?:${pagePrefix}${pageNumber})|` +
-      `(?:${pageNumber}\\s*(?:\\|\\s*)?${pageWord})|` +
-      `(?:(?:${pageWord}\\s*)?${pageNumber}\\s*${ofWord}\\s*${pageNumber})|` +
-      `(?:${before}${pageNumber}${after})` +
-      `)$`,
+    `(?:${pagePrefix}${pageNumber})|` +
+    `(?:${pageNumber}\\s*(?:\\|\\s*)?${pageWord})|` +
+    `(?:(?:${pageWord}\\s*)?${pageNumber}\\s*${ofWord}\\s*${pageNumber})|` +
+    `(?:${before}${pageNumber}${after})` +
+    `)$`,
     'i',
   );
 
@@ -723,34 +720,6 @@ export function getPdfExtractor(config: Config): Extractor {
     default:
       return new PdfminerExtractor(config);
   }
-}
-/*
-  merges multiple PDF files into a single one and writes it in the output path
-*/
-export function mergePDFs(files: string[], output: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    if (!CommandExecuter.isCommandAvailable('gs')) {
-      reject({
-        found: false,
-        error: `GhostScript was not found on the system. Are you sure it is installed and added to PATH?`,
-      });
-    } else {
-      /*
-        the `spawn` of CommandExecuter does not work in this case, it gets stuck in GS CLI
-        TODO: Make this command work with CommandExecuter.
-      */
-      exec(
-        `gs -DNOPAUSE -sDEVICE=pdfwrite -sOUTPUTFILE=${output} -dBATCH ${files.join(' ')}`,
-        (err, stdout, stderr) => {
-          if (err) {
-            reject(stderr);
-          } else {
-            resolve(stdout);
-          }
-        },
-      );
-    }
-  });
 }
 
 export async function convertHTMLToPDF(html: string, outputFile?: string): Promise<string> {


### PR DESCRIPTION
- Removed direct usage of GhostScript command to merge PDF files (used in EmailExtractor).
- Replaced that gs command with [pdfmerge](https://www.npmjs.com/package/pdfmerge) package.
- Added **PyPDF2** to the installation guides and scripts, as it's a required dependency of pdfmerge.
- **Extra:** ran `npm audit fix` on vue-viewer folder. 