### PR TITLE
[toc] - fixed issue with table of contents

### DIFF
--- a/server/defaultConfig.json
+++ b/server/defaultConfig.json
@@ -66,26 +66,17 @@
         "tolerance": 0.25
       }
     ],
+    [
+      "table-of-contents-detection",
+      {
+        "pageKeywords": ["pagina", "page", "pag"]
+      }
+    ],
     "heading-detection",
     "heading-detection-dt",
     "list-detection",
     "page-number-detection",
     "hierarchy-detection",
-    [
-      "table-of-contents-detection",
-      {
-        "keywords": [
-          "contents",
-          "index",
-          "table of contents",
-          "contenidos",
-          "indice",
-          "índice",
-          "tabla de contenidos"
-        ],
-        "pageKeywords": ["pagina", "page", "pag"]
-      }
-    ],
     [
       "regex-matcher",
       {

--- a/server/src/processing/HeadingDetectionModule/HeadingDetectionModule.ts
+++ b/server/src/processing/HeadingDetectionModule/HeadingDetectionModule.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 AXA Group Operations S.A.
+ * Copyright 2020 AXA Group Operations S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import {
   Line,
   Page,
   Paragraph,
+  TableOfContents,
   Word,
 } from '../../types/DocumentRepresentation';
 import * as utils from '../../utils';
@@ -60,7 +61,8 @@ export class HeadingDetectionModule extends Module {
       );
       const paras: Paragraph[] = this.mergeLinesIntoParagraphs(newContents.paragraphLines);
       const headings: Heading[] = this.mergeLinesIntoHeadings(newContents.headingLines);
-      page.elements = newContents.rootElements.concat([...headings, ...paras]);
+      const toc: TableOfContents[] = page.getElementsOfType<TableOfContents>(TableOfContents, false);
+      page.elements = newContents.rootElements.concat([...headings, ...paras, ...toc]);
     });
 
     if (this.headingsDetected(doc)) {
@@ -333,7 +335,7 @@ export class HeadingDetectionModule extends Module {
   }*/
 
   private pageOtherElements(page: Page): Element[] {
-    return page.elements.filter(element => !(element instanceof Paragraph));
+    return page.elements.filter(element => !(element instanceof Paragraph) && !(element instanceof TableOfContents));
   }
 
   private getElementsWithParagraphs(elements: Element[], withParagraphs: Element[]): Element[] {

--- a/server/src/processing/TableOfContentsDetectionModule/TableOfContentsDetectionModule.ts
+++ b/server/src/processing/TableOfContentsDetectionModule/TableOfContentsDetectionModule.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Document, Heading, Paragraph, TableOfContents } from '../../types/DocumentRepresentation';
+import { Document, Paragraph, TableOfContents } from '../../types/DocumentRepresentation';
 import { Module } from '../Module';
 import * as defaultConfig from './defaultConfig.json';
 import * as detection from './detection-methods';
@@ -43,17 +43,13 @@ export class TableOfContentsDetectionModule extends Module<Options> {
         .filter(e => !e.properties.isFooter && !e.properties.isHeader);
 
       const tocItemParagraphs = allParagraphs.filter(p => detection.TOCDetected(p, this.options.pageKeywords));
-      /*
-        - if the page doesn't have any 'TOC' keywords, the detection threshold is increased to avoid false positives.
-        - the detection threshold is increased a little if the previous page didn't have a TOC.
-      */
-      const headings = allParagraphs.filter(p => p instanceof Heading);
+
+      // the detection threshold is increased a little if the previous page didn't have a TOC.
       if (
         tocItemParagraphs.length > 0 &&
         tocItemParagraphs.length >=
         Math.floor(allParagraphs.length
           * detection.threshold
-          * (detection.hasKeyword(headings, this.options.keywords || []) ? 1 : 1.25)
           * Math.pow(1.05, pagesSinceLastTOC))
       ) {
         foundTOC = true;


### PR DESCRIPTION
- Moved TableOfContentsDetectionModule to be executed before HeadingDetectionModule.
- Removed Heading references inside TOCDetection.
- On HeadingDetectionModule, filtered elements inside TOC to **not** be interpreted as Headings.

### BEFORE:
<img width="545" alt="Screenshot 2020-03-17 at 12 13 56" src="https://user-images.githubusercontent.com/11478307/76963026-9cdfbd00-6920-11ea-8885-eb2e3e3cc93d.png">
<img width="681" alt="Screenshot 2020-03-17 at 12 14 05" src="https://user-images.githubusercontent.com/11478307/76963023-9bae9000-6920-11ea-9688-1b71b9e69c29.png">

### AFTER:

<img width="503" alt="Screenshot 2020-03-18 at 14 00 15" src="https://user-images.githubusercontent.com/11478307/76963136-d57f9680-6920-11ea-893e-3ad1edb48500.png">

<img width="684" alt="Screenshot 2020-03-18 at 14 00 21" src="https://user-images.githubusercontent.com/11478307/76963141-d7e1f080-6920-11ea-89fe-1b43bc7ab8b9.png">

