### PR TITLE
SonarQube - Remove pdf.worker.js from analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
 sonar.projectKey=parsr
 sonar.projectName=Parsr
 slack_webhook=https://hooks.slack.com/services/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
+sonar.exclusions=/server/assets/pdf.worker.js


### PR DESCRIPTION
Add exclusion for pdf.worker.js because is a node module configuration file