### PR TITLE
Fixed split words bug on pdf2txt result

### DIFF
--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -189,7 +189,7 @@ function getPage(pageObj: PdfminerPage): Page {
   if (pageObj.textbox !== undefined) {
     pageObj.textbox.forEach(para => {
       para.textline.map(line => {
-        elements = [...elements, ...breakLineIntoWords(line.text, ',', pageBBox.height)];
+        elements = [...elements, ...breakLineIntoWords(line.text, ',', pageBBox.height, 1, para._attr.wmode)];
       });
     });
   }
@@ -316,6 +316,7 @@ function breakLineIntoWords(
   wordSeparator: string = ' ',
   pageHeight: number,
   scalingFactor: number = 1,
+  wMode: string = null,
 ): Word[] {
   const notAllowedChars = ['\u200B']; // &#8203 Zero Width Space
   const words: Word[] = [];
@@ -414,7 +415,12 @@ function breakLineIntoWords(
       }
     }
   }
-  return words;
+
+  return wMode ?
+    words.map(w => {
+      w.properties.writeMode = wMode;
+      return w;
+    }) : words;
 }
 
 function thereAreFakeSpaces(texts: PdfminerText[]): boolean {

--- a/server/src/types/DocumentRepresentation/Word.ts
+++ b/server/src/types/DocumentRepresentation/Word.ts
@@ -43,10 +43,6 @@ export class Word extends Text {
     return this;
   }
 
-  public equals(word: Word): boolean {
-    return JSON.stringify(this) === JSON.stringify(word);
-  }
-
   public toMarkDown(): string {
     let mdString: string;
 

--- a/server/src/types/DocumentRepresentation/Word.ts
+++ b/server/src/types/DocumentRepresentation/Word.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 AXA Group Operations S.A.
+ * Copyright 2020 AXA Group Operations S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,16 @@ export class Word extends Text {
     this.content = content;
     this.font = font;
     this.language = language;
+  }
+
+  public join(word: Word): Word {
+    this.content = this.toString().concat(word.toString());
+    this.box = BoundingBox.merge([this.box, word.box]);
+    return this;
+  }
+
+  public equals(word: Word): boolean {
+    return JSON.stringify(this) === JSON.stringify(word);
   }
 
   public toMarkDown(): string {

--- a/server/src/types/Metadata/Properties.ts
+++ b/server/src/types/Metadata/Properties.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 AXA Group Operations S.A.
+ * Copyright 2020 AXA Group Operations S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ export interface Properties {
     capitalCase: number;
     titleCase: number;
   };
-
+  writeMode?: string;
   isRedundant?: boolean;
   isHeader?: boolean;
   isFooter?: boolean;

--- a/server/src/types/PdfminerTextbox.ts
+++ b/server/src/types/PdfminerTextbox.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 AXA Group Operations S.A.
+ * Copyright 2020 AXA Group Operations S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import { PdfminerTextline } from './PdfminerTextline';
 export class PdfminerTextbox {
   public _attr: {
     id: string;
+    wmode: string;
     bbox: string;
   };
   public textline: PdfminerTextline[];


### PR DESCRIPTION
Fixed a bug with pdf2txt `--detect-vertical` argument were some characters are interpreted as vertical text, splitting the word in two. (vertical detection is working as usual)

**Before:**
<img width="638" alt="Screenshot 2020-03-20 at 09 35 07" src="https://user-images.githubusercontent.com/11478307/77147957-cfa7c380-6a8e-11ea-81a8-209f4bb9cf74.png">

```
Headings
- Identical heading detected: 305 / 1099 (27.75)%
- Detected heading (wrong lvl): 675 / 1099 (61.41)%
- False Positive : 583
- Missed Heading : 424
```

**After:**
<img width="680" alt="Screenshot 2020-03-20 at 09 34 30" src="https://user-images.githubusercontent.com/11478307/77147969-d7676800-6a8e-11ea-9efe-0b2e6b368670.png">

```
Headings
- Identical heading detected: 387 / 1099 (35.21)%
- Detected heading (wrong lvl): 793 / 1099 (72.15)%
- False Positive : 465
- Missed Heading : 306
```
