### PR TITLE
Add a default config file for CLI

### DIFF
--- a/scripts/copyFiles/index.js
+++ b/scripts/copyFiles/index.js
@@ -1,8 +1,8 @@
 var shell = require('shelljs');
 
-if (!shell.test('-d', './dist/assets')) {
-  shell.mkdir('./dist', './dist/assets');
+if (!shell.test('-d', './dist/assets') || !shell.test('-d', './dist/bin')) {
+  shell.mkdir('./dist', './dist/assets', './dist/bin');
 }
 shell.cp('-u', './server/assets/*.py', './dist/assets/');
 shell.cp('-u', './server/assets/pdf.worker.js', './node_modules/pdfjs-dist/build/');
-shell.cp('-u', './server/defaultConfig.json', './dist/bin');
+shell.cp('-u', './server/defaultConfig.json', './dist/bin/');

--- a/scripts/copyFiles/index.js
+++ b/scripts/copyFiles/index.js
@@ -5,3 +5,4 @@ if (!shell.test('-d', './dist/assets')) {
 }
 shell.cp('-u', './server/assets/*.py', './dist/assets/');
 shell.cp('-u', './server/assets/pdf.worker.js', './node_modules/pdfjs-dist/build/');
+shell.cp('-u', './server/defaultConfig.json', './dist/bin');

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -49,6 +49,7 @@ function main(): void {
     .option(
       '-c, --config <filename>',
       "The file's path from which the application's parameters will be loaded",
+      `${__dirname}/defaultConfig.json`
     )
     .option(
       '-l, --log-level <verbosity>',

--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -49,7 +49,7 @@ function main(): void {
     .option(
       '-c, --config <filename>',
       "The file's path from which the application's parameters will be loaded",
-      `${__dirname}/defaultConfig.json`
+      `${__dirname}/defaultConfig.json`,
     )
     .option(
       '-l, --log-level <verbosity>',


### PR DESCRIPTION
The idea ios that we use the default config file for CLI if no config file is provided -> Ease of use.

- Change the index.ts to support a default vaule to defaultConfig.json
- Change copy asset script to bundle the defaultConfig in the dist folder.