### PR TITLE
[split-words] - added param to pdf2txt to avoid word splitting

### DIFF
--- a/server/src/utils/CommandExecuter.ts
+++ b/server/src/utils/CommandExecuter.ts
@@ -188,6 +188,7 @@ export async function pdfMinerExtract(filePath: string, pages: string, rotationD
     '-R', rotationDegrees.toString(),
     '-c', 'utf-8',
     '-t', 'xml',
+    '--word-margin', '0.2',
     '-o', xmlOutputFile,
     filePath,
   ];


### PR DESCRIPTION
- added new parameter to pdf2txt.py to avoid word splitting on file icann.pdf

related issue: https://github.com/pdfminer/pdfminer.six/issues/402