### PR TITLE
Refactor/LinkDetectionModule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parsr",
-  "version": "0.11.0",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5158,11 +5158,6 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "svgson": "^3.1.0",
     "tslint": "^5.19.0",
     "xml-stream": "^0.4.5",
-    "xml2js": "^0.4.23",
-    "xmldom": "^0.1.31"
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@types/archiver": "^3.1.0",

--- a/server/src/input/pdfminer/PdfminerExtractor.ts
+++ b/server/src/input/pdfminer/PdfminerExtractor.ts
@@ -19,6 +19,7 @@ import * as CommandExecuter from '../../utils/CommandExecuter';
 import logger from '../../utils/Logger';
 import { extractImagesAndFonts } from '../extractImagesFonts';
 import { Extractor } from '../Extractor';
+import * as utils from './../../utils';
 import * as pdfminer from './pdfminer';
 
 /**
@@ -78,7 +79,7 @@ export class PdfminerExtractor extends Extractor {
     const extractPages = this.pagesToExtract(pageIndex, maxPages, totalPages);
     return pdfminer
       .extractPages(inputFile, totalPages != null ? extractPages : null)
-      .then(pdfminer.sanitizeXML)
+      .then(utils.sanitizeXML)
       .then(pdfminer.xmlParser)
       .then(pdfminer.jsParser)
       .then(this.detectAndFixPageRotation(inputFile))

--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -29,7 +29,6 @@ import { Color } from '../../types/DocumentRepresentation/Color';
 import { PdfminerFigure } from '../../types/PdfminerFigure';
 import { PdfminerPage } from '../../types/PdfminerPage';
 import { PdfminerText } from '../../types/PdfminerText';
-import * as utils from '../../utils';
 import * as CommandExecuter from '../../utils/CommandExecuter';
 import logger from '../../utils/Logger';
 
@@ -61,24 +60,6 @@ export function extractPages(
       .catch(({ error }) => {
         rejectXml(`PdfMiner pdf2txt.py error: ${error}`);
       });
-  });
-}
-export function sanitizeXML(xmlPath: string): Promise<string> {
-  const startTime: number = Date.now();
-  return new Promise<any>((resolve, _reject) => {
-    try {
-      // repplace with empty char everything forbidden by XML 1.0 specifications,
-      // plus the unicode replacement character U+FFFD
-      const regex = /((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]))/g;
-      const xml: string = fs.readFileSync(xmlPath, 'utf-8');
-      const outputFilePath = utils.getTemporaryFile('.xml');
-      fs.writeFileSync(outputFilePath, xml.replace(new RegExp(regex), ' '));
-      logger.info(`Sanitize XML: ${(Date.now() - startTime) / 1000}s`);
-      resolve(outputFilePath);
-    } catch (error) {
-      logger.warn(`Error sanitizing XML ${error}`);
-      resolve(xmlPath);
-    }
   });
 }
 

--- a/server/src/processing/LinkDetectionModule/LinkDetectionModule.ts
+++ b/server/src/processing/LinkDetectionModule/LinkDetectionModule.ts
@@ -15,10 +15,10 @@
  */
 import * as filetype from 'file-type';
 import * as fs from 'fs';
-import { DOMParser } from 'xmldom';
 import { BoundingBox, Document, Page, Word } from '../../types/DocumentRepresentation';
 import * as utils from '../../utils';
 import * as CommandExecuter from '../../utils/CommandExecuter';
+import { DumpPdfLink, DumpPdfLinksResponse, extractLinks } from '../../utils/DumpPdfUtils';
 import logger from '../../utils/Logger';
 import { Module } from '../Module';
 
@@ -34,7 +34,7 @@ export class LinkDetectionModule extends Module {
   public static moduleName = 'link-detection';
 
   public async main(doc: Document): Promise<Document> {
-    let mdLinks: JSON[] = [];
+    let mdLinks: DumpPdfLinksResponse[] = [];
     const fileType: { ext: string; mime: string } = filetype(fs.readFileSync(doc.inputFile));
     if (fileType === null || fileType.ext !== 'pdf') {
       logger.warn(
@@ -42,23 +42,26 @@ export class LinkDetectionModule extends Module {
         not using meta info for link detection..`,
       );
     } else {
-      mdLinks = await this.extractLinksFromMetadata(doc.inputFile);
-      mdLinks = mdLinks.map((link, id) => ({
-        ...link,
-        id,
-      }));
+      mdLinks = await this.getFileMetadata(doc.inputFile);
     }
 
-    doc.pages.forEach((page: Page) => {
-      const links = mdLinks.filter(link => parseInt((link as any).page, 10) === page.pageNumber);
+    const count = mdLinks.reduce((acc, l) => acc + l.links.length, 0);
+    logger.info('Found ' + count + ' links in document metadata.');
 
+    doc.pages.forEach((page: Page) => {
+      const pageLinks = mdLinks.find(l => l.pageNumber + 1 === page.pageNumber);
       page.getElementsOfType<Word>(Word, true).forEach(word => {
         // for a given word, check if the word matches any not used link position.
-        links.forEach(link => {
-          const l = link as any;
-          const linkBB = new BoundingBox(l.box.l, l.box.t, l.box.w, l.box.h);
+        (pageLinks || { links: [] }).links.forEach(pageLink => {
+          const linkBB = new BoundingBox(
+            pageLink.box.left,
+            page.height - pageLink.box.top,
+            pageLink.box.width,
+            pageLink.box.height,
+          );
+
           if (Math.abs(BoundingBox.getOverlap(linkBB, word.box).box2OverlapProportion) > 0.7) {
-            word.properties.targetURL = this.buildLinkTarget(l);
+            word.properties.targetURL = this.buildLinkTarget(pageLink);
           }
         });
 
@@ -71,7 +74,7 @@ export class LinkDetectionModule extends Module {
   }
 
   private matchTextualLinks(word: Word) {
-    const linkRegexp = /\b((http|https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))/;
+    const linkRegexp = /\b((http|https):\/\/?|(www))[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))/;
     // tslint:disable-next-line:max-line-length
     const mailRegexp = /^(("[\w-\s]+")|([\w-]+(?:\.[\w-]+)*)|("[\w-\s]+")([\w-]+(?:\.[\w-]+)*))(@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$)|(@\[?((25[0-5]\.|2[0-4][0-9]\.|1[0-9]{2}\.|[0-9]{1,2}\.))((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){2}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\]?$)/;
     if (word.toString().match(linkRegexp)) {
@@ -84,147 +87,23 @@ export class LinkDetectionModule extends Module {
   /*
     runs the 'dumppdf.py' script and returns a JSON with all the metadata found in the file
   */
-  private getFileMetadata(pdfFilePath: string): Promise<any> {
-    return new Promise((resolve, reject) => {
+  private getFileMetadata(pdfFilePath: string): Promise<DumpPdfLinksResponse[]> {
+    return new Promise((resolve) => {
       CommandExecuter.dumpPdf(pdfFilePath)
-        .then(xmlOutputPath => {
-          const xml: string = fs.readFileSync(xmlOutputPath, 'utf8');
-          try {
-            logger.debug(`Converting dumppdf's XML output to JS object..`);
-            const xmlStringSerialized = new DOMParser().parseFromString(xml, 'text/xml');
-            utils.parseXmlToObject(xmlStringSerialized).then((obj: any) => {
-              resolve(obj);
-            });
-          } catch (err) {
-            reject(`parseXml failed: ${err}`);
-          }
+        .then(utils.sanitizeXML)
+        .then(extractLinks)
+        .then(links => {
+          resolve(links);
         })
         .catch(() => {
-          resolve();
+          resolve([]);
         });
     });
   }
-  /*private getFileMetadata_(pdfFilePath: string): Promise<any> {
-    return new Promise((resolve, reject) => {
-      logger.info(`Extracting metadata with pdfminer's dumppdf.py tool...`);
-      const xmlOutputFile: string = utils.getTemporaryFile('.xml');
-      const dumppdfArguments = ['-a', '-o', xmlOutputFile, pdfFilePath];
 
-      if (!fs.existsSync(xmlOutputFile)) {
-        fs.appendFileSync(xmlOutputFile, '');
-      }
-      CommandExecuter.run(CommandExecuter.COMMANDS.DUMPPDF, dumppdfArguments)
-        .then(() => {
-          const xml: string = fs.readFileSync(xmlOutputFile, 'utf8');
-          try {
-            logger.debug(`Converting dumppdf's XML output to JS object..`);
-            const xmlStringSerialized = new DOMParser().parseFromString(xml, 'text/xml');
-            utils.parseXmlToObject(xmlStringSerialized).then((obj: any) => {
-              resolve(obj);
-            });
-          } catch (err) {
-            reject(`parseXml failed: ${err}`);
-          }
-        })
-        .catch(({ found, error }) => {
-          logger.error(error);
-          if (!found) {
-            reject(`Could not find the necessary libraries..`);
-          } else {
-            reject(error);
-          }
-        });
-    });
-  }*/
-
-  /*
-    parses the JSON metadata given by dumppdf.py and returns only the matched links on each page
-  */
-  private async extractLinksFromMetadata(file: string): Promise<JSON[]> {
-    const annots = [];
-    try {
-      const {
-        pdf: { object: objects },
-      } = await this.getFileMetadata(file);
-
-      const pages = objects.filter(
-        o => o.dict && o.dict[0].value.some(v => v.literal && v.literal.includes('Page')),
-      );
-      const pagesWithAnnots = pages.filter(o => o.dict && o.dict[0].key.includes('Annots'));
-      pagesWithAnnots.forEach(pageObject => {
-        const pageHeightIndex = pageObject.dict[0].key.indexOf('MediaBox');
-        const pageHeight = pageObject.dict[0].value[pageHeightIndex].list[0].number[3];
-
-        let pageAnnots = [];
-        const annotsValueIndex = pageObject.dict[0].key.indexOf('Annots');
-        const annotsValue = pageObject.dict[0].value[annotsValueIndex];
-        const annotObjIds = annotsValue.list
-          ? annotsValue.list[0].ref.map(item => item.$.id)
-          : annotsValue.ref.map(item => item.$.id);
-
-        pageAnnots = (function deepSearchObjectsWithIds(ids: string[]): any[] {
-          const result = [];
-          ids.forEach(id => {
-            const obj = objects.find(o => o.$.id === id);
-            if (obj.dict) {
-              result.push(obj);
-            } else {
-              result.push(...deepSearchObjectsWithIds(obj.list[0].ref.map(o => o.$.id)));
-            }
-          });
-          return result;
-        })(annotObjIds);
-
-        pageAnnots = pageAnnots.map(annot => {
-          const rectValueIndex = annot.dict[0].key.indexOf('Rect');
-          const linkValueIndex = annot.dict[0].key.indexOf('A');
-          if (rectValueIndex !== -1 && linkValueIndex !== -1) {
-            const numbers = annot.dict[0].value[rectValueIndex].list[0].number;
-            return {
-              box: {
-                l: parseFloat(numbers[0]),
-                t: pageHeight - numbers[3],
-                w: numbers[2] - numbers[0],
-                h: numbers[3] - numbers[1],
-              },
-              link: this.parseLinkByActionType(annot.dict[0].value[linkValueIndex].dict[0]),
-              page: pages.map(p => p.$.id).findIndex(p => p === pageObject.$.id) + 1,
-            };
-          } else {
-            return undefined;
-          }
-        });
-
-        annots.push(...pageAnnots.filter(a => a !== undefined));
-      });
-
-      logger.info('Found ' + annots.length + ' links in PDF metadata.');
-    } catch (error) {
-      logger.info(error);
-    }
-    return annots;
-  }
-
-  private parseAction(obj: any, type: string): any {
-    const index = obj.key.findIndex(k => k === type);
-    return obj.value[index].string[0]._;
-  }
-
-  private parseLinkByActionType(obj: any): any {
-    const typeIndex = obj.key.findIndex(k => k === 'S');
-    const type = obj.value[typeIndex].literal[0];
-    const typeMap = {
-      GoTo: 'D',
-    };
-    return {
-      target: this.parseAction(obj, typeMap[type] || type),
-      type,
-    };
-  }
-
-  private buildLinkTarget(l: any): string {
-    let targetURL = l.link.target;
-    if (l.link.type === 'GoTo') {
+  private buildLinkTarget(l: DumpPdfLink): string {
+    let targetURL = l.anchor.target;
+    if (l.anchor.type === 'GoTo') {
       targetURL = '#'.concat(targetURL);
     }
     return targetURL;

--- a/server/src/processing/LinkDetectionModule/README.md
+++ b/server/src/processing/LinkDetectionModule/README.md
@@ -2,20 +2,20 @@
 
 ## Purpose
 
-The Link detection module detects URLs, GoTo links, as well as actionLaunch, actionNamed, actionMovie based links in a PDF document, when used on a pdf2json output.
+The Link detection module detects URLs, GoTo and mailto links inside PDF metadata and it's text contents.
 
 ## What it does
 
-It appends a the link found on a word (extracted by pdfminer) to the word's content itself, by transforming the content to an html `<a>` link.
+It adds the property `targetURL` to the matching Words.
 
 ## Dependencies
 
-None
+None.
 
 ## How it works
 
-1. It compares each word to three Regex patterns, one looking for URI based link contents, one looking for GoTo links as well as any other Action links.
-2. For each case, a suitable representation, like `<a>` for URIs, is attached with the content of the word itself.
+1. It uses pdfminer's `dumppdf` utility and `xml-stream` library to process document metadata as XML and find links with their bounding boxes and page number.
+2. Also for each word on document it uses two RegExp to match URL's or emails as strings and also set their `targetURL`
 
 ## Accuracy
 
@@ -23,5 +23,4 @@ All correctly detected links from the extractor are well preserved, and the accu
 
 ## Limitations
 
-- As long as the pdf2json extractor is used, links are preserved, as it is the only currently present extractor with link detection and preservation capacity.
-- Links are included in the body of the concerned word, instead of an actual Link element. This is a TODO.
+- Any 'Action' type link inside metadata is ignored for now. (Can't match their respective bounding boxes).

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -768,3 +768,22 @@ function embedImagesInHTML(html: string): string {
   }
   return html;
 }
+
+export function sanitizeXML(xmlPath: string): Promise<string> {
+  const startTime: number = Date.now();
+  return new Promise<any>((resolve, _reject) => {
+    try {
+      // repplace with empty char everything forbidden by XML 1.0 specifications,
+      // plus the unicode replacement character U+FFFD
+      const regex = /((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|(?:&#\d*;)))/g;
+      const xml: string = fs.readFileSync(xmlPath, 'utf-8');
+      const outputFilePath = getTemporaryFile('.xml');
+      fs.writeFileSync(outputFilePath, xml.replace(new RegExp(regex), ' '));
+      logger.info(`Sanitize XML: ${(Date.now() - startTime) / 1000}s`);
+      resolve(outputFilePath);
+    } catch (error) {
+      logger.warn(`Error sanitizing XML ${error}`);
+      resolve(xmlPath);
+    }
+  });
+}

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -21,7 +21,6 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { inspect } from 'util';
-import { OptionsV2, parseString } from 'xml2js';
 import { Extractor } from './input/Extractor';
 import { PDFJsExtractor } from './input/pdf.js/PDFJsExtractor';
 import { PdfminerExtractor } from './input/pdfminer/PdfminerExtractor';
@@ -654,18 +653,6 @@ export function groupConsecutiveNumbersInArray(theArray: number[]): number[][] {
       return r;
     }, []);
   return result;
-}
-
-export function parseXmlToObject(xml: string, options: OptionsV2 = null): Promise<object> {
-  const promise = new Promise<object>((resolveObject, rejectObject) => {
-    parseString(xml, options, (error, dataObject) => {
-      if (error) {
-        rejectObject(error);
-      }
-      resolveObject(dataObject);
-    });
-  });
-  return promise;
 }
 
 export function getEmphazisChars(text: string): string {

--- a/server/src/utils/DumpPdfUtils.ts
+++ b/server/src/utils/DumpPdfUtils.ts
@@ -141,13 +141,13 @@ export function extractLinks(xmlPath: string): Promise<DumpPdfLinksResponse[]> {
 }
 
 /*
-  this looks that a particular nested structure defined in @param keys exists on @param o.
+  this looks that a particular nested structure defined in @param keys exists on @param node.
   ex:
-    hasNestedKeys({ foo: { bar: { baz: 10 } } }, ['foo', 'bar', 'baz']) === true, structure "o.foo.bar.baz" is valid
-    hasNestedKeys({ foo: { bar: { baz: 10 } } }, ['foo', 'baz']) === false, structure "o.foo.baz" is not valid
+    hasNestedKeys({ foo: { bar: { baz: 10 } } }, ['foo', 'bar', 'baz']) === true, structure "node.foo.bar.baz" is valid
+    hasNestedKeys({ foo: { bar: { baz: 10 } } }, ['foo', 'baz']) === false, structure "node.foo.baz" is not valid
 */
-function hasNestedKeys(o: any, keys: string[]): boolean {
-  let search = Object.assign({}, o);
+function hasNestedKeys(node: any, keys: string[]): boolean {
+  let search = Object.assign({}, node);
   return keys.every(k => {
     if (search.hasOwnProperty(k)) {
       search = search[k];
@@ -174,11 +174,11 @@ function xmlNodeToLink(node: any): DumpPdfLink {
   }
   const [x1, y1, x2, y2] = node.dict.value[node.dict.key.findIndex(k => k === 'Rect')].list.number
     .map(x => parseInt(x, 10));
-  const A = node.dict.value[node.dict.key.findIndex(k => k === 'A')];
-  if (A) {
-    if (hasNestedKeys(A, ['dict', 'key']) && hasNestedKeys(A, ['dict', 'value'])) {
-      const type = A.dict.value[A.dict.key.findIndex(k => k === 'S')].literal;
-      const target = A.dict.value[A.dict.key.findIndex(k => k === (type === 'URI' ? 'URI' : 'D'))];
+  const annotInfo = node.dict.value[node.dict.key.findIndex(k => k === 'A')];
+  if (annotInfo) {
+    if (hasNestedKeys(annotInfo, ['dict', 'key']) && hasNestedKeys(annotInfo, ['dict', 'value'])) {
+      const type = annotInfo.dict.value[annotInfo.dict.key.findIndex(k => k === 'S')].literal;
+      const target = annotInfo.dict.value[annotInfo.dict.key.findIndex(k => k === (type === 'URI' ? 'URI' : 'D'))];
       if (!target || !hasNestedKeys(target, ['string', '$text'])) {
         return null;
       }

--- a/server/src/utils/DumpPdfUtils.ts
+++ b/server/src/utils/DumpPdfUtils.ts
@@ -1,0 +1,236 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createReadStream } from 'fs';
+import * as XmlStream from 'xml-stream';
+
+export type DumpPdfLink = {
+  nodeId: string;
+  anchor: {
+    type: 'URI' | 'GoTo';
+    target: string;
+  },
+  box: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  }
+};
+
+export type DumpPdfLinksResponse = {
+  pageNumber: number;
+  links: DumpPdfLink[];
+};
+
+type DumpPdfLinkingNode = {
+  nodeId: string;
+  children: string[];
+};
+
+export function extractLinks(xmlPath: string): Promise<DumpPdfLinksResponse[]> {
+  return new Promise((resolve, reject) => {
+    const xmlStream = new XmlStream(createReadStream(xmlPath, { encoding: 'utf8' }));
+
+    let pagesInfo = [];
+    const nodesToDeepSearch = [];
+    const annots = [];
+    const linkNodes = [];
+    const pagesWithAnnots = {};
+
+    xmlStream.collect('key');
+    xmlStream.collect('value');
+    xmlStream.collect('list > ref');
+    xmlStream.collect('list > number');
+
+    xmlStream.on('endElement: object', node => {
+      let foundNodeType = false;
+
+      if (nodesToDeepSearch.includes(node.$.id)) {
+        if (hasNestedKeys(node, ['list', 'ref'])) {
+          nodesToDeepSearch.push(...node.list.ref.map(r => r.$.id));
+        }
+      }
+
+      if (nodeIs(node, 'Type', 'Pages')) {
+        foundNodeType = true;
+        if (hasNestedKeys(node, ['dict', 'key']) && hasNestedKeys(node, ['dict', 'value'])) {
+          const pageKids = node.dict.value[node.dict.key.findIndex(k => k === 'Kids')];
+          if (pageKids && hasNestedKeys(pageKids, ['list', 'ref'])) {
+            pagesInfo.push(...pageKids.list.ref.map(r => r.$.id));
+          }
+        }
+      }
+
+      if (nodeIs(node, 'Type', 'Page')) {
+        foundNodeType = true;
+        if (hasNestedKeys(node, ['dict', 'key']) && hasNestedKeys(node, ['dict', 'value'])) {
+          const annotPage = node.dict.value[node.dict.key.findIndex(k => k === 'Annots')];
+          if (!pagesWithAnnots[node.$.id]) {
+            pagesWithAnnots[node.$.id] = [];
+          }
+          if (annotPage && hasNestedKeys(annotPage, ['list', 'ref'])) {
+            pagesWithAnnots[node.$.id].push(...annotPage.list.ref.map(r => r.$.id));
+          } else if (annotPage && hasNestedKeys(annotPage, ['ref', '$', 'id'])) {
+            pagesWithAnnots[node.$.id].push(annotPage.ref.$.id);
+            nodesToDeepSearch.push(annotPage.ref.$.id);
+          }
+        }
+      }
+
+      if (nodeIs(node, 'Type', 'Annot') || nodeIs(node, 'Subtype', 'Link')) {
+        foundNodeType = true;
+        if (hasNestedKeys(node, ['dict', 'key']) && hasNestedKeys(node, ['dict', 'value'])) {
+          const a = node.dict.value[node.dict.key.findIndex(k => k === 'A')];
+          if (hasNestedKeys(a, ['ref', '$', 'id']) && !hasNestedKeys(a, ['dict'])) {
+            nodesToDeepSearch.push(a.ref.$.id);
+          } else {
+            annots.push(node);
+          }
+        }
+      }
+
+      // 'Action' type nodes have targetURLs, but don't include bbox data, so they are ignored.
+      if (nodeIs(node, 'Type', 'Action')) {
+        foundNodeType = true;
+      }
+
+      if (
+        nodesToDeepSearch.includes(node.$.id)
+        && !foundNodeType
+        && !hasNestedKeys(node, ['dict', 'value'])
+      ) {
+        linkNodes.push(node);
+      }
+    });
+
+    xmlStream.on('error', message => {
+      reject(message);
+    });
+
+    xmlStream.on('end', () => {
+      pagesInfo = pagesInfo.filter(p => Object.keys(pagesWithAnnots).includes(p));
+      const links: DumpPdfLink[] = annots.map(xmlNodeToLink).filter(l => !!l);
+      const linksData = Object.keys(pagesWithAnnots)
+        .map(nodeId => {
+          return {
+            pageNumber: pagesInfo.findIndex(p => p === nodeId),
+            links: pagesWithAnnots[nodeId]
+              .map(matchLinks(links, linkNodes.map(xmlToLinkingNode)))
+              .reduce((acc, array) => acc.concat(...array), []),
+          };
+        })
+        .filter(p => p.links.length > 0);
+
+      resolve(linksData);
+    });
+  });
+}
+
+/*
+  this looks that a particular nested structure defined in @param keys exists on @param o.
+  ex:
+    hasNestedKeys({ foo: { bar: { baz: 10 } } }, ['foo', 'bar', 'baz']) === true, structure "o.foo.bar.baz" is valid
+    hasNestedKeys({ foo: { bar: { baz: 10 } } }, ['foo', 'baz']) === false, structure "o.foo.baz" is not valid
+*/
+function hasNestedKeys(o: any, keys: string[]): boolean {
+  let search = Object.assign({}, o);
+  return keys.every(k => {
+    if (search.hasOwnProperty(k)) {
+      search = search[k];
+      return true;
+    }
+    return false;
+  });
+}
+
+function nodeIs(node: any, type: string, value: string): boolean {
+  if (hasNestedKeys(node, ['dict', 'key']) && hasNestedKeys(node, ['dict', 'value'])) {
+    const objType = node.dict.value[node.dict.key.findIndex(k => k === type)];
+    if (objType && hasNestedKeys(objType, ['literal']) && objType.literal === value) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function xmlNodeToLink(node: any): DumpPdfLink {
+  const rect = node.dict.value[node.dict.key.findIndex(k => k === 'Rect')];
+  if (!rect || !hasNestedKeys(rect, ['list', 'number'])) {
+    return null;
+  }
+  const [x1, y1, x2, y2] = node.dict.value[node.dict.key.findIndex(k => k === 'Rect')].list.number
+    .map(x => parseInt(x, 10));
+  const A = node.dict.value[node.dict.key.findIndex(k => k === 'A')];
+  if (A) {
+    if (hasNestedKeys(A, ['dict', 'key']) && hasNestedKeys(A, ['dict', 'value'])) {
+      const type = A.dict.value[A.dict.key.findIndex(k => k === 'S')].literal;
+      const target = A.dict.value[A.dict.key.findIndex(k => k === (type === 'URI' ? 'URI' : 'D'))];
+      if (!target || !hasNestedKeys(target, ['string', '$text'])) {
+        return null;
+      }
+      return {
+        nodeId: node.$.id,
+        anchor: {
+          target: target.string.$text,
+          type,
+        },
+        box: {
+          height: y2 - y1,
+          left: x1,
+          top: y2,
+          width: x2 - x1,
+        },
+      };
+    }
+  } else {
+    const dest = node.dict.value[node.dict.key.findIndex(k => k === 'Dest')];
+    if (dest && dest.literal) {
+      return {
+        nodeId: node.$.id,
+        anchor: {
+          target: dest.literal,
+          type: 'GoTo',
+        },
+        box: {
+          height: y2 - y1,
+          left: x1,
+          top: y2,
+          width: x2 - x1,
+        },
+      };
+    }
+  }
+  return null;
+}
+
+function xmlToLinkingNode(node: any): DumpPdfLinkingNode {
+  return {
+    nodeId: node.$.id,
+    children: node.list.ref.map(r => r.$.id),
+  };
+}
+
+function matchLinks(links: DumpPdfLink[], linkingNodes: DumpPdfLinkingNode[]):
+  (nodeId) => DumpPdfLink[] {
+  return (nodeId: string): DumpPdfLink[] => {
+    const linkingNode = linkingNodes.find(n => n.nodeId === nodeId);
+    if (linkingNode) {
+      return links.filter(l => linkingNode.children.includes(l.nodeId));
+    }
+    return links.filter(l => l.nodeId === nodeId);
+  };
+}


### PR DESCRIPTION
LinkDetectionModule refactor:
- moved `sanitizeXML` function to utils file.
- removed `xmldom` unused dependency.
- removed `parseXmlToObject` unused function.
- used `xml-stream` to process dumppdf output and find links inside it.
- modified 'textual links' RegExp to also match URLs starting with `www.`