### PR TITLE
Add a simple JSON output that is easier to use.

### DIFF
--- a/server/bin/index.ts
+++ b/server/bin/index.ts
@@ -26,6 +26,7 @@ import { JsonExtractor } from '../src/input/json/JsonExtractor';
 import { Orchestrator } from '../src/Orchestrator';
 import { CsvExporter } from '../src/output/csv/CsvExporter';
 import { JsonExporter } from '../src/output/json/JsonExporter';
+import { SimpleJsonExporter } from '../src/output/simpleJson/SimpleJsonExporter';
 import { MarkdownExporter } from '../src/output/markdown/MarkdownExporter';
 import { PdfExporter } from '../src/output/pdf/PdfExporter';
 import { TextExporter } from '../src/output/text/TextExporter';
@@ -139,6 +140,15 @@ function main(): void {
             ),
           );
         }
+        if (config.output.formats.simpleJson) {
+          promises.push(
+            new SimpleJsonExporter(doc, false).export(
+              `${outputFolder}/${omitFilenameExtension(documentName)}.simple.json`,
+            ),
+          );
+        }
+
+
 
         // if (config.output.formats['json-compact']) {
         // 	promises.push(

--- a/server/defaultConfig.json
+++ b/server/defaultConfig.json
@@ -106,7 +106,8 @@
       "text": true,
       "csv": true,
       "markdown": true,
-      "pdf": false
+      "pdf": false,
+      "simpleJson" : true
     }
   }
 }

--- a/server/src/output/index.ts
+++ b/server/src/output/index.ts
@@ -17,6 +17,7 @@
 export * from './Exporter';
 export * from './json/JsonExporter';
 export * from './json/JsonCompactExporter';
+export * from './simpleJson/SimpleJsonExporter';
 export * from './markdown/MarkdownExporter';
 export * from './text/TextExporter';
 export * from './xml/XmlExporter';

--- a/server/src/output/simpleJson/README.md
+++ b/server/src/output/simpleJson/README.md
@@ -1,0 +1,3 @@
+# Simple json
+
+Export a simplier JSON Structure

--- a/server/src/output/simpleJson/SimpleJsonExporter.ts
+++ b/server/src/output/simpleJson/SimpleJsonExporter.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Document,
+  Heading,
+  List,
+  Paragraph,
+  Table,
+} from '../../types/DocumentRepresentation';
+import { TableOfContents } from '../../types/DocumentRepresentation/TableOfContents';
+import logger from '../../utils/Logger';
+import { Exporter } from '../Exporter';
+
+export class SimpleJsonExporter extends Exporter {
+  private includeHeaderFooter: boolean;
+
+  constructor(doc: Document, includeHeaderFooter: boolean) {
+    super(doc);
+    this.includeHeaderFooter = includeHeaderFooter;
+  }
+
+  public export(outputPath: string): Promise<any> {
+    logger.info('Exporting markdown...');
+    return this.writeFile(outputPath, this.getSimpleJSON());
+  }
+
+  private getSimpleJSON(): string {
+    const simpleJSON = [];
+    this.doc.pages.forEach((page) => {
+      page.elements.forEach(element => {
+        if (
+          (element.properties.isHeader || element.properties.isFooter) &&
+          !this.includeHeaderFooter
+        ) {
+          return;
+        }
+        if (element instanceof Heading) {
+          simpleJSON.push(element.toSimpleJSON());
+        } else if (element instanceof Paragraph) {
+          simpleJSON.push(element.toSimpleJSON());
+        } else if (element instanceof List) {
+          simpleJSON.push(element.toSimpleJSON());
+        } else if (element instanceof Table) {
+          simpleJSON.push(element.toSimpleJSON());
+        } else if (element instanceof TableOfContents) {
+          simpleJSON.push(element.toSimpleJSON());
+        }
+      });
+    });
+    return JSON.stringify(simpleJSON);
+  }
+}

--- a/server/src/types/Config.ts
+++ b/server/src/types/Config.ts
@@ -54,6 +54,7 @@ export interface OutputConfig {
   includeMarginals: boolean;
   formats: {
     json?: boolean;
+    simpleJson?: boolean;
     // 'json-compact'?: boolean;
     text?: boolean;
     markdown?: boolean;

--- a/server/src/types/DocumentRepresentation/Heading.ts
+++ b/server/src/types/DocumentRepresentation/Heading.ts
@@ -62,4 +62,15 @@ export class Heading extends Paragraph {
     }
     return '#'.repeat(this.level) + ' ' + this.toString();
   }
+
+  public toSimpleJSON(): any {
+    if (this.level === 0) {
+      return super.toSimpleJSON();
+    }
+    return {
+      type : 'heading',
+      level : this.level,
+      content : this.toString(),
+    };
+  }
 }

--- a/server/src/types/DocumentRepresentation/List.ts
+++ b/server/src/types/DocumentRepresentation/List.ts
@@ -118,12 +118,21 @@ export class List extends Element {
     return this.export('md');
   }
 
+  public toSimpleJSON(): any {
+    return {
+      type : 'list',
+      content : this.export('simple'),
+    };
+  }
+
   private export(type: string): string {
     let output: string = '';
     this.content.forEach((para, index) => {
       let paraText: string = '';
       if (type === 'md') {
         paraText = para.toMarkdown();
+      } else if (type === 'simple') {
+        paraText = para.toSimpleJSON().content;
       } else {
         paraText = para.toString();
       }

--- a/server/src/types/DocumentRepresentation/Table.ts
+++ b/server/src/types/DocumentRepresentation/Table.ts
@@ -323,6 +323,22 @@ export class Table extends Element {
     return this.exportAsMD();
   }
 
+  public toSimpleJSON(): any {
+    const tableArray = this.toArray();
+    const output: any = [];
+    tableArray.forEach((row) => {
+      const r = [];
+      row.forEach(cellMDCode => {
+        r.push(cellMDCode);
+      });
+      output.push(r);
+    });
+    return {
+      type : 'table',
+      content : output,
+    };
+  }
+
   public exportAsHtml(): string {
     let output: string = '<table>  \n';
     this.content.forEach(row => {

--- a/server/src/types/DocumentRepresentation/TableOfContents.ts
+++ b/server/src/types/DocumentRepresentation/TableOfContents.ts
@@ -57,6 +57,14 @@ export class TableOfContents extends Element {
   public toMarkdown() {
     return this.items.map(c => c.toMarkdown()).join('  \n');
   }
+
+  public toSimpleJSON(): any {
+    return {
+      type : 'tableOfContent',
+      content : this.items.map(c => c.toString()),
+    };
+  }
+
   public toString() {
     return this.items.map(c => c.toString()).join('\n');
   }


### PR DESCRIPTION
 Use the simpleJSON:true in config to activate the simple Json output.

This json output will be save as filename.simple.json in the out dir.

It's structured is simplified and easier to use for building quick usecases.