### PR TITLE
[license] - added missing license headers

### DIFF
--- a/scripts/copyFiles/index.js
+++ b/scripts/copyFiles/index.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 var shell = require('shelljs');
 
 if (!shell.test('-d', './dist/assets') || !shell.test('-d', './dist/bin')) {

--- a/scripts/preinstall/darwin.commands.js
+++ b/scripts/preinstall/darwin.commands.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { join } = require('path');
 
 module.exports = ['/bin/bash', '-c', join(__dirname, 'darwin.bash.sh')];

--- a/scripts/preinstall/index.js
+++ b/scripts/preinstall/index.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const { spawn } = require('child_process');
 const { platform } = require('os');
 

--- a/scripts/preinstall/windows.commands.js
+++ b/scripts/preinstall/windows.commands.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 const commands = [
   'Set-ExecutionPolicy Bypass -Scope Process -Force',

--- a/test/table-detection.spec.ts
+++ b/test/table-detection.spec.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { expect } from 'chai';
 import * as fs from 'fs';
 import 'mocha';
@@ -28,6 +44,7 @@ describe('No Table detection function', () => {
   });
 
   it('should have no table detected', () => {
+    // tslint:disable-next-line
     expect(table).not.exist;
   });
 });
@@ -57,6 +74,7 @@ describe('One Table detection function', () => {
   });
 
   it('should have one table detected', () => {
+    // tslint:disable-next-line
     expect(table).exist;
   });
 


### PR DESCRIPTION
- used [license-header-checker](https://github.com/lsm-dev/license-header-checker/ ) to detect and "fix" files without the license header.
- disabled tslint rule on a couple of lines (pre-commit hook was failing)