### PR TITLE
Table of contents

### DIFF
--- a/server/src/processing/TableOfContentsDetectionModule/TableOfContentsDetectionModule.ts
+++ b/server/src/processing/TableOfContentsDetectionModule/TableOfContentsDetectionModule.ts
@@ -39,18 +39,19 @@ export class TableOfContentsDetectionModule extends Module<Options> {
     for (let i = 0; i <= doc.pages.length - 1 && (!foundTOC || pagesSinceLastTOC < 5); i++) {
       const page = doc.pages[i];
 
-      const allParagraphs = page.getElementsOfType<Paragraph>(Paragraph, false)
-        .filter(e => !e.properties.isFooter && !e.properties.isHeader);
+      const allParagraphs = page
+        .getElementsOfType<Paragraph>(Paragraph, false)
+        .filter(this.isNotHeaderFooter);
 
-      const tocItemParagraphs = allParagraphs.filter(p => detection.TOCDetected(p, this.options.pageKeywords));
+      const tocItemParagraphs = allParagraphs.filter(p =>
+        detection.TOCDetected(p, this.options.pageKeywords),
+      );
 
       // the detection threshold is increased a little if the previous page didn't have a TOC.
       if (
         tocItemParagraphs.length > 0 &&
         tocItemParagraphs.length >=
-        Math.floor(allParagraphs.length
-          * detection.threshold
-          * Math.pow(1.05, pagesSinceLastTOC))
+          Math.floor(allParagraphs.length * detection.threshold * Math.pow(1.05, pagesSinceLastTOC))
       ) {
         foundTOC = true;
         const toc = new TableOfContents();
@@ -65,5 +66,12 @@ export class TableOfContentsDetectionModule extends Module<Options> {
     }
 
     return doc;
+  }
+
+  private isNotHeaderFooter(paragraph: Paragraph): boolean {
+    const allWords = paragraph.content.map(line => line.content).reduce((a, b) => a.concat(b), []);
+    return (
+      allWords.filter(word => !word.properties.isFooter && !word.properties.isHeader).length > 0
+    );
   }
 }


### PR DESCRIPTION
Exclude words detected as Footer or Header from being part of a TOC

- Before
<img width="690" alt="Screenshot 2020-04-15 at 10 28 00" src="https://user-images.githubusercontent.com/12429149/79315897-ea415100-7f03-11ea-9e0b-a5db7c4ae3be.png">
- After
<img width="653" alt="Screenshot 2020-04-15 at 10 23 07" src="https://user-images.githubusercontent.com/12429149/79315906-eca3ab00-7f03-11ea-916d-9cce458fce77.png">
