### PR TITLE
Feature/drawing detection

### DIFF
--- a/demo/vue-viewer/src/components/PageInspector.vue
+++ b/demo/vue-viewer/src/components/PageInspector.vue
@@ -75,7 +75,7 @@
             ></v-switch>
             <v-switch
               v-model="shapesFilter"
-              label="Shapes"
+              label="Drawings"
               class="switch"
               color="indigo darken-3"
               :hide-details="true"

--- a/server/defaultConfig.json
+++ b/server/defaultConfig.json
@@ -6,6 +6,7 @@
     "language": ["eng", "fra"]
   },
   "cleaner": [
+    "drawing-detection",
     [
       "image-detection",
       {

--- a/server/src/Cleaner.ts
+++ b/server/src/Cleaner.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { DrawingDetectionModule } from './processing/DrawingDetectionModule/DrawingDetectionModule';
 import { HeaderFooterDetectionModule } from './processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule';
 import { HeadingDetectionDTModule } from './processing/HeadingDetectionDtModule/HeadingDetectionDtModule';
 import { HeadingDetectionModule } from './processing/HeadingDetectionModule/HeadingDetectionModule';
@@ -76,6 +77,7 @@ export class Cleaner {
     RemoteModule,
     SeparateWordsModule,
     TableOfContentsDetectionModule,
+    DrawingDetectionModule,
     // Add your own module here!
   ];
 

--- a/server/src/input/pdf.js/OperatorsManager.ts
+++ b/server/src/input/pdf.js/OperatorsManager.ts
@@ -299,7 +299,7 @@ export class OperatorsManager {
   }
 
   private filterPerimeterLines(l: SvgLine): boolean {
-    const [x, y] = [l.fromX, l.fromY];
+    const [x, y] = [l.fromX, l.fromY].map(n => Math.round(n));
     // vertical line
     if (l.isVertical() && (x <= 0 || x >= this.viewport.width)) {
       return false;

--- a/server/src/input/pdf.js/OperatorsManager.ts
+++ b/server/src/input/pdf.js/OperatorsManager.ts
@@ -295,21 +295,19 @@ export class OperatorsManager {
     }
 
     // filter lines that follow the perimeter of the page
-    parsedElements.push(...lines.filter(l => {
-      const [x1, x2, y1, y2] = [l.fromX, l.toX, l.fromY, l.toY].map(n => Math.floor(n));
-      // vertical line
-      if (x1 === x2) {
-        if (x1 <= 0 || x1 >= this.viewport.width) {
-          return false;
-        }
-        // horizontal line
-      } else if (y1 === y2) {
-        if (y1 <= 0 || y1 >= this.viewport.height) {
-          return false;
-        }
-      }
-      return true;
-    },
-    ));
+    parsedElements.push(...lines.filter(this.filterPerimeterLines));
+  }
+
+  private filterPerimeterLines(l: SvgLine): boolean {
+    const [x, y] = [l.fromX, l.fromY];
+    // vertical line
+    if (l.isVertical() && (x <= 0 || x >= this.viewport.width)) {
+      return false;
+    }
+    // horizontal line
+    if (l.isHorizontal() && (y <= 0 || y >= this.viewport.height)) {
+      return false;
+    }
+    return true;
   }
 }

--- a/server/src/input/pdf.js/OperatorsManager.ts
+++ b/server/src/input/pdf.js/OperatorsManager.ts
@@ -295,7 +295,7 @@ export class OperatorsManager {
     }
 
     // filter lines that follow the perimeter of the page
-    parsedElements.push(...lines.filter(this.filterPerimeterLines));
+    parsedElements.push(...lines.filter(this.filterPerimeterLines, this));
   }
 
   private filterPerimeterLines(l: SvgLine): boolean {

--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -19,7 +19,6 @@ import {
   BoundingBox,
   Character,
   Document,
-  Drawing,
   Element,
   Font,
   Image,
@@ -238,14 +237,14 @@ function getPage(pageObj: PdfminerPage): Page {
   // treat svg lines and rectangles
   if (pageObj.shapes !== undefined) {
     pageObj.shapes.forEach(shape => {
-      elements.push(shapeToDrawing(shape, pageBBox.height));
+      elements.push(...pdfminerShapeToSvgShapes(shape, pageBBox.height));
     });
   }
 
   return new Page(parseFloat(pageObj._attr.id), elements, pageBBox);
 }
 
-function shapeToDrawing(shape: PdfminerShape, pageHeight: number): Drawing {
+function pdfminerShapeToSvgShapes(shape: PdfminerShape, pageHeight: number): SvgShape[] {
   const drawingBox: BoundingBox = getBoundingBox(shape._attr.bbox, ',', pageHeight);
 
   const thickness = parseFloat(shape._attr.linewidth) || 1;
@@ -294,7 +293,7 @@ function shapeToDrawing(shape: PdfminerShape, pageHeight: number): Drawing {
     }
   }
 
-  return new Drawing(drawingBox, drawingContent);
+  return drawingContent;
 }
 
 function hasTexts(figure: PdfminerFigure): boolean {

--- a/server/src/input/pdfminer/pdfminer.ts
+++ b/server/src/input/pdfminer/pdfminer.ts
@@ -246,7 +246,7 @@ function getPage(pageObj: PdfminerPage): Page {
 }
 
 function filterPerimeterLines(l: SvgLine, pageBox: BoundingBox): boolean {
-  const [x, y] = [l.fromX, l.fromY];
+  const [x, y] = [l.fromX, l.fromY].map(n => Math.round(n));
   // vertical line
   if (l.isVertical() && (x <= 0 || x >= pageBox.width)) {
     return false;

--- a/server/src/processing/DrawingDetectionModule/DrawingDetectionModule.ts
+++ b/server/src/processing/DrawingDetectionModule/DrawingDetectionModule.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2020 AXA Group Operations S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BoundingBox, Document, Drawing } from '../../types/DocumentRepresentation';
+import { SvgLine } from '../../types/DocumentRepresentation/SvgLine';
+import logger from '../../utils/Logger';
+import { Module } from '../Module';
+
+/**
+ * groups together SvgLines that are visually connected
+ */
+export class DrawingDetectionModule extends Module {
+  public static moduleName = 'drawing-detection';
+
+  public async main(doc: Document): Promise<Document> {
+
+    if (doc.getElementsOfType<Drawing>(Drawing).length > 0) {
+      logger.warn('Document already has Drawings. Skipping...');
+      return doc;
+    }
+
+    doc.pages.forEach(page => {
+      const lines = page.getElementsOfType<SvgLine>(SvgLine, true);
+      const drawings: Drawing[] = [];
+      this.groupShapesIntoDrawings(lines, page.box, drawings);
+
+      // filter all SvgLine type elements and push Drawings containing those Lines
+      const lineIds = lines.map(l => l.id);
+      page.elements = page.elements.filter(e => !lineIds.includes(e.id));
+      page.elements.push(...drawings);
+    });
+    logger.info(`${doc.getElementsOfType<Drawing>(Drawing).length} drawings found on document.`);
+    return doc;
+  }
+
+  private groupShapesIntoDrawings(svgLines: SvgLine[], box: BoundingBox, foundDrawings: Drawing[]) {
+
+    const { columns, rows } = this.groupLines(svgLines, box);
+
+    if (columns.length > 1) {
+      // divide the box into columns.length cols and recall function for each one
+      columns.forEach(svgColumn => {
+        this.groupShapesIntoDrawings(svgColumn, box, foundDrawings);
+      });
+    } else if (rows.length > 1) {
+      // divide the box into rows.length rows and recall function for each one
+      rows.forEach(svgRow => {
+        this.groupShapesIntoDrawings(svgRow, box, foundDrawings);
+      });
+    } else {
+      const lines = columns[0];
+      if (lines) {
+        // a Drawing was found, the content in columns and rows is the same
+        const drawing = new Drawing(null, lines);
+        drawing.updateBoundingBox();
+        foundDrawings.push(drawing);
+      }
+    }
+  }
+
+  private groupLines(svgLines: SvgLine[], box: BoundingBox): { columns: SvgLine[][], rows: SvgLine[][] } {
+
+    // vertical line
+    const vControlLine = new SvgLine(null, 1, box.left, box.top, box.left, box.bottom);
+    const groupedColumns = this.processGroup(svgLines, box, vControlLine);
+
+    // horizontal line
+    const hControlLine = new SvgLine(null, 1, box.left, box.top, box.width, box.top);
+    const groupedRows = this.processGroup(svgLines, box, hControlLine);
+
+    return {
+      columns: groupedColumns,
+      rows: groupedRows,
+    };
+  }
+
+  /**
+   * does a vertical/horizontal sweep of the page SvgLines (similar to page margins calculation)
+   * and detects separation gaps between those lines.
+   *
+   * @param lines lines to process into groups
+   * @param box boundingBox of the current page area to sweep
+   * @param controlLine 'sweeper' line can be horizontal or vertical. longitude is set based on the current line group
+   * @returns SvgLine[][],
+   * where each element of the array are SvgLines that are vertically/horizontally grouped
+   */
+  private processGroup(lines: SvgLine[], box: BoundingBox, controlLine: SvgLine): SvgLine[][] {
+    const groups: SvgLine[][] = [];
+    const processedLineIds: number[] = [];
+    let currentLineGroup: SvgLine[] = [];
+
+    // until controlLine reaches the v/h end of the page
+    // if controlLine is vertical, the sweep is done from left to right
+    // if controlLine is horizontal, the sweep is done from top to bottom
+    const type = controlLine.isVertical() ? 'h' : 'v';
+    while (
+      (type === 'v' ? controlLine.toY : controlLine.toX)
+      < (type === 'v' ? box.height : box.width)
+    ) {
+      const intersectingLines = lines.filter(l => controlLine.intersects(l) || this.controlLineIsOver(l, controlLine));
+      if (intersectingLines.length > 0) {
+        const unusedLines = intersectingLines.filter(l => !processedLineIds.includes(l.id));
+        if (unusedLines.length > 0) {
+          currentLineGroup.push(...unusedLines);
+          processedLineIds.push(...unusedLines.map(l => l.id));
+        }
+      } else {
+        // if no intersectingLines were found,
+        // it means the controlLine is on a "gap between drawings" so a group has been found
+        if (currentLineGroup.length > 0) {
+          groups.push(currentLineGroup);
+          currentLineGroup = [];
+        }
+      }
+
+      // at the end of each iteration, move the control line
+      controlLine.move(
+        type === 'v' ? 0 : 1,
+        type === 'v' ? 1 : 0,
+      );
+    }
+
+    if (currentLineGroup.length > 0) {
+      groups.push(currentLineGroup);
+    }
+
+    return groups;
+  }
+
+  /**
+   * As lines position are floating poing values,
+   * this avoids controlLine to jump over the line without detecting it
+   */
+  private controlLineIsOver(line: SvgLine, controlLine: SvgLine): boolean {
+    const is1pxAroundLineX = controlLine.fromX + 0.5 >= line.fromX && controlLine.fromX - 0.5 <= line.fromX;
+    const is1pxAroundLineY = controlLine.fromY + 0.5 >= line.fromY && controlLine.fromY - 0.5 <= line.fromY;
+    return (controlLine.isVertical() && is1pxAroundLineX) || (controlLine.isHorizontal() && is1pxAroundLineY);
+  }
+}

--- a/server/src/processing/DrawingDetectionModule/README.md
+++ b/server/src/processing/DrawingDetectionModule/README.md
@@ -1,0 +1,26 @@
+# Drawing Detection Module
+
+## Purpose
+
+Groups SvgShapes into Drawings
+
+## What it does
+
+Converts all SvgShapes given by the extractor to a group of Drawings. Each Drawing is a set of Shapes that are visually together.
+
+## Dependencies
+
+None
+
+## How it works
+
+It sweeps each document page with a vertical and a horizontal control line, finding separations between groups. 
+
+## Accuracy
+
+Very high.
+The boundaries of each page and element however, need to be correctly specified by the extractor.
+
+## Limitations
+
+None

--- a/server/src/processing/DrawingDetectionModule/defaultConfig.json
+++ b/server/src/processing/DrawingDetectionModule/defaultConfig.json
@@ -1,0 +1,4 @@
+{
+	"name": "drawing-detection-module",
+	"description": "groups svg Shapes that are visually part of a Drawing."
+}

--- a/server/src/types/DocumentRepresentation/Drawing.ts
+++ b/server/src/types/DocumentRepresentation/Drawing.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 AXA Group Operations S.A.
+ * Copyright 2020 AXA Group Operations S.A.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 import { BoundingBox } from './BoundingBox';
 import { Element } from './Element';
+import { SvgLine } from './SvgLine';
 import { SvgShape } from './SvgShape';
 
 /**
@@ -44,6 +45,15 @@ export class Drawing extends Element {
    */
   public set content(value: SvgShape[]) {
     this._content = value;
+  }
+
+  public updateBoundingBox() {
+    const lines: SvgLine[] = (this.content.filter(c => c instanceof SvgLine) as SvgLine[]);
+    const minY = Math.min(...lines.map(l => l.fromY), ...lines.map(l => l.toY));
+    const maxY = Math.max(...lines.map(l => l.fromY), ...lines.map(l => l.toY));
+    const minX = Math.min(...lines.map(l => l.fromX), ...lines.map(l => l.toX));
+    const maxX = Math.max(...lines.map(l => l.fromX), ...lines.map(l => l.toX));
+    this.box = new BoundingBox(minX, minY, maxX - minX, maxY - minY);
   }
 
   public toString(): string {

--- a/server/src/types/DocumentRepresentation/SvgLine.ts
+++ b/server/src/types/DocumentRepresentation/SvgLine.ts
@@ -175,7 +175,44 @@ export class SvgLine extends SvgShape {
     this.toY = toY;
   }
 
-  public toString(): string {
-    return this.fromX + ',' + this.toX + ',' + this.fromY + ',' + this.toY + ',' + this.color + ';';
+  // https://stackoverflow.com/questions/9043805/test-if-two-lines-intersect-javascript-function
+  public intersects(line: SvgLine): boolean {
+    const a = this.fromX;
+    const b = this.fromY;
+    const c = this.toX;
+    const d = this.toY;
+
+    const p = line.fromX;
+    const q = line.fromY;
+    const r = line.toX;
+    const s = line.toY;
+
+    const det = (c - a) * (s - q) - (r - p) * (d - b);
+    if (det === 0) {
+      return false;
+    } else {
+      const lambda = ((s - q) * (r - a) + (p - r) * (s - b)) / det;
+      const gamma = ((b - d) * (r - a) + (c - a) * (s - b)) / det;
+      return (0 <= lambda && lambda <= 1) && (0 <= gamma && gamma <= 1);
+    }
+  }
+
+  public move(xDiff: number, yDiff: number) {
+    this.fromX += xDiff;
+    this.toX += xDiff;
+    this.fromY += yDiff;
+    this.toY += yDiff;
+  }
+
+  public isVertical(): boolean {
+    return Math.abs(this.rotationAngle()) === 90;
+  }
+
+  public isHorizontal(): boolean {
+    return this.rotationAngle() === 0 || this.rotationAngle() === 180;
+  }
+
+  private rotationAngle(): number {
+    return Math.atan2(this.toY - this.fromY, this.toX - this.fromX) * 180 / Math.PI;
   }
 }


### PR DESCRIPTION
New 'drawing-detection-module' 

**What it does?** Groups together SVG elements that are visually part of a Drawing.

**Why?** This is an important step to increase table detection accuracy. With this module enabled, TableDetectionModule can get every "table-like" Drawing and run camelot on those areas. Also, Drawings can be used to improve/fix camelot output.

Examples: (different line color means different Drawing element).
Line coloring is only to show each Drawing in this examples, and **it's not part of this PR**.

<img width="592" alt="Screenshot 2020-05-11 at 14 18 19" src="https://user-images.githubusercontent.com/11478307/81563573-b6d4d380-9396-11ea-8314-104b36ec0df5.png">
<img width="601" alt="Screenshot 2020-05-11 at 14 20 30" src="https://user-images.githubusercontent.com/11478307/81563580-b9372d80-9396-11ea-9953-7b9f37511471.png">
<img width="661" alt="twotables_1" src="https://user-images.githubusercontent.com/11478307/81563584-b9cfc400-9396-11ea-915d-d40f9132e733.png">
