### PR TITLE
DrawingDetectionModule fixes

### DIFF
--- a/server/src/types/DocumentRepresentation/BoundingBox.ts
+++ b/server/src/types/DocumentRepresentation/BoundingBox.ts
@@ -19,6 +19,10 @@
  * element, using the elements height, width, left and top. Other than a regular constructor,
  * the bounding box can also be constructed using a merge of multiple existing bounding box types.
  */
+
+import { maxValue, minValue } from './../../utils';
+import { SvgLine } from './SvgLine';
+
 export class BoundingBox {
   /**
    * Getter left
@@ -136,11 +140,11 @@ export class BoundingBox {
   public static getOverlap(
     box1: BoundingBox,
     box2: BoundingBox,
-    ): {
-      jaccardIndex: number,
-      box1OverlapProportion: number,
-      box2OverlapProportion: number,
-    } {
+  ): {
+    jaccardIndex: number,
+    box1OverlapProportion: number,
+    box2OverlapProportion: number,
+  } {
     const result = {
       jaccardIndex: 0.0,
       box1OverlapProportion: 0.0,
@@ -210,5 +214,16 @@ export class BoundingBox {
    */
   public areaIsEmpty(): boolean {
     return this.height === 0 || this.width === 0;
+  }
+
+  public static fromLines(lines: SvgLine[]): BoundingBox {
+    const xValues = lines.map(l => l.fromX).concat(lines.map(l => l.toX));
+    const yValues = lines.map(l => l.fromY).concat(lines.map(l => l.toY));
+
+    const minX = minValue(xValues);
+    const maxX = maxValue(xValues);
+    const minY = minValue(yValues);
+    const maxY = maxValue(yValues);
+    return new BoundingBox(minX, minY, maxX - minX, maxY - minY);
   }
 }

--- a/server/src/types/DocumentRepresentation/Drawing.ts
+++ b/server/src/types/DocumentRepresentation/Drawing.ts
@@ -18,7 +18,7 @@ import { BoundingBox } from './BoundingBox';
 import { Element } from './Element';
 import { SvgLine } from './SvgLine';
 import { SvgShape } from './SvgShape';
-
+import { maxValue, minValue } from './../../utils';
 /**
  * The Drawing element for the Document Representation structure, which contains an SVG shape,
  * along with its bounding box.
@@ -49,10 +49,17 @@ export class Drawing extends Element {
 
   public updateBoundingBox() {
     const lines: SvgLine[] = (this.content.filter(c => c instanceof SvgLine) as SvgLine[]);
-    const minY = Math.min(...lines.map(l => l.fromY), ...lines.map(l => l.toY));
-    const maxY = Math.max(...lines.map(l => l.fromY), ...lines.map(l => l.toY));
-    const minX = Math.min(...lines.map(l => l.fromX), ...lines.map(l => l.toX));
-    const maxX = Math.max(...lines.map(l => l.fromX), ...lines.map(l => l.toX));
+
+    const yValues = lines.map(l => l.fromY).concat(lines.map(l => l.toY));
+    const xValues = lines.map(l => l.fromX).concat(lines.map(l => l.toX));
+
+    // array of values could be very big, so I need to avoid calling Math.max and Math.min
+    // https://stackoverflow.com/questions/42623071/maximum-call-stack-size-exceeded-with-math-min-and-math-max
+    const minY = minValue(yValues);
+    const maxY = maxValue(yValues);
+    const minX = minValue(xValues);
+    const maxX = maxValue(xValues);
+
     this.box = new BoundingBox(minX, minY, maxX - minX, maxY - minY);
   }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -788,3 +788,23 @@ export function rgbToHex(r: number, g: number, b: number) {
       .join('')
   );
 }
+
+export function minValue(arr: number[]) {
+  let len = arr.length;
+  let min = Infinity;
+
+  while (len--) {
+    min = arr[len] < min ? arr[len] : min;
+  }
+  return min;
+}
+
+export function maxValue(arr: number[]) {
+  let len = arr.length;
+  let max = -Infinity;
+
+  while (len--) {
+    max = arr[len] > max ? arr[len] : max;
+  }
+  return max;
+}


### PR DESCRIPTION
- on `groupShapesIntoDrawing` function, adapted the target box to the current SvgLines array instead of always using the page box, reducing the iteration count on the while block. Also the while condition was using `height` and `width` instead of `bottom` and `right`, finishing the iteration before reaching the actual end of the box.
- on `Drawing` class, replaced Math.max and Math.min with a custom function to calculate those values. Math.max and Math.min throw `max call stack size exceeded` for very big arrays. Explanation [here](https://stackoverflow.com/questions/42623071/maximum-call-stack-size-exceeded-with-math-min-and-math-max).