### PR TITLE
Fix/pdfminer

### DIFF
--- a/server/src/output/json/JsonExporter.ts
+++ b/server/src/output/json/JsonExporter.ts
@@ -274,7 +274,9 @@ export class JsonExporter extends Exporter {
     } else if (element instanceof TableCell) {
       jsonElement.rowspan = element.rowspan;
       jsonElement.colspan = element.colspan;
-      jsonElement.content = element.content.map(elem => this.elementToJsonElement(elem));
+      jsonElement.content = element.content
+        .sort(utils.sortElementsByOrder)
+        .map(elem => this.elementToJsonElement(elem));
     } else if (element instanceof SvgShape) {
       if (element instanceof SvgLine) {
         jsonElement.fromX = element.fromX;


### PR DESCRIPTION
Fixed a bug on pdfminer output where sometimes it was not specifying a blank space between two characters of different words, making this words to join together.
Now it's also considering the position of each character on the page to determine if there should be a separation.

**Also:** Paragraphs inside TableCells were not being exported in the correct order.

This seems to have fixed the bug found on icann.pdf, but the overall words and headings accuracy decreased a little. (maybe there are more docs with the same problem)

example: (icann, page 18)
<img width="435" alt="Screenshot 2020-06-15 at 15 59 44" src="https://user-images.githubusercontent.com/11478307/84666765-c7421600-af21-11ea-9218-0e13d7666baa.png">

after:
<img width="433" alt="Screenshot 2020-06-15 at 15 59 11" src="https://user-images.githubusercontent.com/11478307/84666810-d7f28c00-af21-11ea-93eb-36eadd14f7a4.png">

**Benchmark before**:
```json
------------------------------------------------------------
        > Final score based on 110 files <
------------------------------------------------------------
Word accuracy
- Word delta: 46054
- Total words in truth: 1926421
- Accuracy: 97.61%
------------------------------------------------------------
Text Similarity (Combined levenshtein per page)
- Levenshtein distance: 945499
- Levenshtein accuracy: 50.92%
------------------------------------------------------------
Block reconstruction
- Detected blocks: 9025 / 7474 (+1551)
- Identical blocks: 4720 / 7474 (63.15%)
- Identical blocks @L10: 6079 / 7474 (81.34%)
- Identical blocks @L25: 6704 / 7474 (89.70%)
------------------------------------------------------------
Headings
- Identical heading detected: 951 / 1855 (51.27)%
- Level accuracy: 951 / 1403 (67.78)%
- Detected heading (wrong lvl): 1403 / 1855 (75.63)%
- False Positive: 479
- Missed Heading: 452
- Accuracy: 25.44%
- Recall: 0.7699206491270727
- Precision: 0.7970561376998817
- F1-score: 0.7682511861892456
------------------------------------------------------------
Table
- False positives: 7
- Tables in truth: 156
- Detected tables: 135
- Cells in annoted document : 10362
- Correctly identified cells : 5296
- Misplaced cells : 1671
- Detection accuracy : 82.05%
- Reconstruction accuracy : 51.11%
------------------------------------------------------------
Lists
- Identical list items: 1149
- List item in result: 1496
- List item in thruth: 1522
- Missed list item: 373
- False positives list item: 347
- List Item accuracy: 52.69%
------------------------------------------------------------
Links (without images)
- Detected links: 351 / 453 (+41)
- False positives: 41
- Identical links: 214 / 453 (47.24%)
------------------------------------------------------------
===> The entire operation took 1h 4m 15s
```

**benchmark after:**
```json
------------------------------------------------------------
        > Final score based on 110 files <
------------------------------------------------------------
Word accuracy
- Word delta: 47020
- Total words in truth: 1926421
- Accuracy: 97.56%
------------------------------------------------------------
Text Similarity (Combined levenshtein per page)
- Levenshtein distance: 945499
- Levenshtein accuracy: 50.92%
------------------------------------------------------------
Block reconstruction
- Detected blocks: 9046 / 7474 (+1572)
- Identical blocks: 4677 / 7474 (62.58%)
- Identical blocks @L10: 6118 / 7474 (81.86%)
- Identical blocks @L25: 6769 / 7474 (90.57%)
------------------------------------------------------------
Headings
- Identical heading detected: 973 / 1855 (52.45)%
- Level accuracy: 973 / 1424 (68.33)%
- Detected heading (wrong lvl): 1424 / 1855 (76.77)%
- False Positive: 490
- Missed Heading: 431
- Accuracy: 26.04%
- Recall: 0.7653591503074277
- Precision: 0.783854763358587
- F1-score: 0.7630061517645514
------------------------------------------------------------
Table
- False positives: 7
- Tables in truth: 156
- Detected tables: 135
- Cells in annoted document : 10362
- Correctly identified cells : 5375
- Misplaced cells : 1667
- Detection accuracy : 82.05%
- Reconstruction accuracy : 51.87%
------------------------------------------------------------
Lists
- Identical list items: 1136
- List item in result: 1493
- List item in thruth: 1522
- Missed list item: 386
- False positives list item: 357
- List Item accuracy: 51.18%
------------------------------------------------------------
Links (without images)
- Detected links: 357 / 453 (+47)
- False positives: 47
- Identical links: 213 / 453 (47.02%)
------------------------------------------------------------
===> The entire operation took 1h 10m 33s
```