### PR TITLE
Header footer fix

### DIFF
--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -129,12 +129,8 @@ export class HeaderFooterDetectionModule extends Module<Options> {
     );
     return true;
   }
-  private boolToInt(p) {
-    if (p) {
-      return 1;
-    } else {
-      return 0;
-    }
+  private boolToInt(occupancy: boolean) : number{
+      return (occupancy? 1 : 0);
   }
 
   private setMargins(

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -64,6 +64,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
           const v: number[] = page.verticalOccupancy.map(this.boolToInt);
           occupancyAcrossWidth = utils.addVectors(occupancyAcrossWidth, v);
         });
+        
         // UNCOMMENT THESE TO EXPORT OCCUPANCIES INTO EXTERNAL CSV FILES
         // writeFileSync("horizontal.csv", occupancyAcrossWidth.join(";"), {encoding: 'utf-8'})
         // writeFileSync("vertical.csv", occupancyAcrossHeight.join(";"), {encoding: 'utf-8'})
@@ -83,6 +84,8 @@ export class HeaderFooterDetectionModule extends Module<Options> {
             element.properties.isHeader = true;
           }
         });
+        occupancyAcrossHeight = [];
+        occupancyAcrossWidth = [];
       });
     logger.debug('Done with marginals detection.');
     return doc;

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -129,7 +129,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
     );
     return true;
   }
-  private boolToInt(occupancy: boolean) : number {
+  private boolToInt(occupancy: boolean): number {
       return occupancy ? 1 : 0;
   }
 

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -216,12 +216,14 @@ export class HeaderFooterDetectionModule extends Module<Options> {
   }
 
   private storePageSimilarSize(pagesStoredBySize: Page[][], page: Page) {
+    const maxSizeSimilarity: number = 1 + this.options.similaritySizePercentage / 100;
+    const minSizeSimilarity: number = 1 / maxSizeSimilarity;
     const indexValue = pagesStoredBySize.findIndex(
       pageSize =>
-        pageSize[0].width * 0.9 <= page.width &&
-        pageSize[0].width * 1.1 >= page.width &&
-        pageSize[0].height * 0.9 <= page.height &&
-        pageSize[0].height * 1.1 >= page.height,
+        pageSize[0].width * minSizeSimilarity <= page.width &&
+        pageSize[0].width * maxSizeSimilarity >= page.width &&
+        pageSize[0].height * minSizeSimilarity <= page.height &&
+        pageSize[0].height * maxSizeSimilarity >= page.height,
     );
     if (indexValue !== -1 && pagesStoredBySize[indexValue].indexOf(page) === -1) {
       pagesStoredBySize[indexValue].push(page);

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -96,66 +96,63 @@ export class HeaderFooterDetectionModule extends Module<Options> {
         const v: number[] = page.verticalOccupancy.map(boolToInt);
         occupancyAcrossWidth = utils.addVectors(occupancyAcrossWidth, v);
       });
-    });
 
-    // UNCOMMENT THESE TO EXPORT OCCUPANCIES INTO EXTERNAL CSV FILES
-    // writeFileSync("horizontal.csv", occupancyAcrossWidth.join(";"), {encoding: 'utf-8'})
-    // writeFileSync("vertical.csv", occupancyAcrossHeight.join(";"), {encoding: 'utf-8'})
+      // UNCOMMENT THESE TO EXPORT OCCUPANCIES INTO EXTERNAL CSV FILES
+      // writeFileSync("horizontal.csv", occupancyAcrossWidth.join(";"), {encoding: 'utf-8'})
+      // writeFileSync("vertical.csv", occupancyAcrossHeight.join(";"), {encoding: 'utf-8'})
 
-    const heightZeros: number[] = utils
-      .findPositionsInArray(occupancyAcrossHeight, 0)
-      .sort((a, b) => {
-        return a - b;
-      });
-    const widthZeros: number[] = utils
-      .findPositionsInArray(occupancyAcrossWidth, 0)
-      .sort((a, b) => {
-        return a - b;
-      });
+      const heightZeros: number[] = utils
+        .findPositionsInArray(occupancyAcrossHeight, 0)
+        .sort((a, b) => {
+          return a - b;
+        });
+      const widthZeros: number[] = utils
+        .findPositionsInArray(occupancyAcrossWidth, 0)
+        .sort((a, b) => {
+          return a - b;
+        });
 
-    const maxT: number = Math.floor(
-      0 + (this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
-    );
-    doc.margins.top = heightZeros
-      .filter(value => value < maxT)
-      .sort((a, b) => {
-        return b - a;
-      })[0];
-    const maxB: number = Math.floor(
-      occupancyAcrossHeight.length -
-        (this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
-    );
-    doc.margins.bottom = heightZeros
-      .filter(value => value > maxB)
-      .sort((a, b) => {
-        return a - b;
-      })[0];
-    const maxL: number = Math.floor(
-      0 + (this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
-    );
-    doc.margins.left = widthZeros
-      .filter(value => value < maxL)
-      .sort((a, b) => {
-        return b - a;
-      })[0];
-    const maxR: number = Math.floor(
-      occupancyAcrossWidth.length -
-        (this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
-    );
-    doc.margins.right = widthZeros
-      .filter(value => value > maxR)
-      .sort((a, b) => {
-        return a - b;
-      })[0];
+      const maxT: number = Math.floor(
+        0 + (this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
+      );
+      doc.margins.top = heightZeros
+        .filter(value => value < maxT)
+        .sort((a, b) => {
+          return b - a;
+        })[0];
+      const maxB: number = Math.floor(
+        occupancyAcrossHeight.length -
+          (this.options.maxMarginPercentage * occupancyAcrossHeight.length) / 100,
+      );
+      doc.margins.bottom = heightZeros
+        .filter(value => value > maxB)
+        .sort((a, b) => {
+          return a - b;
+        })[0];
+      const maxL: number = Math.floor(
+        0 + (this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
+      );
+      doc.margins.left = widthZeros
+        .filter(value => value < maxL)
+        .sort((a, b) => {
+          return b - a;
+        })[0];
+      const maxR: number = Math.floor(
+        occupancyAcrossWidth.length -
+          (this.options.maxMarginPercentage * occupancyAcrossWidth.length) / 100,
+      );
+      doc.margins.right = widthZeros
+        .filter(value => value > maxR)
+        .sort((a, b) => {
+          return a - b;
+        })[0];
 
-    logger.info(
-      `Document margins for maxMarginPercentage ${this.options.maxMarginPercentage}: ` +
-        `top: ${doc.margins.top}, bottom: ${doc.margins.bottom}, ` +
-        `left: ${doc.margins.left}, right: ${doc.margins.right}`,
-    );
-
-    doc.pages
-      .filter(p => !this.options.ignorePages.includes(p.pageNumber))
+      logger.info(
+        `Document margins for maxMarginPercentage ${this.options.maxMarginPercentage}: ` +
+          `top: ${doc.margins.top}, bottom: ${doc.margins.bottom}, ` +
+          `left: ${doc.margins.left}, right: ${doc.margins.right}`,
+      );
+      groupOfPage
       .forEach(page => {
         const headerElements: Element[] = page.getElementsSubset(
           new BoundingBox(0, 0, page.width, doc.margins.top),
@@ -173,6 +170,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
           element.properties.isHeader = true;
         }
       });
+    });
     logger.debug('Done with marginals detection.');
     return doc;
   }

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  BoundingBox,
-  Document,
-  Element,
-} from '../../types/DocumentRepresentation';
+import { BoundingBox, Document, Element } from '../../types/DocumentRepresentation';
 import * as utils from '../../utils';
 import logger from '../../utils/Logger';
 import { Module } from '../Module';
@@ -87,7 +83,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
     }
 
     doc.pages
-      .filter(p => !this.options.ignorePages.includes(p))
+      .filter(p => !this.options.ignorePages.includes(p.pageNumber))
       .forEach(page => {
         const h: number[] = page.horizontalOccupancy.map(boolToInt);
         occupancyAcrossHeight = utils.addVectors(occupancyAcrossHeight, h);
@@ -151,23 +147,25 @@ export class HeaderFooterDetectionModule extends Module<Options> {
         `left: ${doc.margins.left}, right: ${doc.margins.right}`,
     );
 
-    doc.pages.forEach(page => {
-      const headerElements: Element[] = page.getElementsSubset(
-        new BoundingBox(0, 0, page.width, doc.margins.top),
-      );
+    doc.pages
+      .filter(p => !this.options.ignorePages.includes(p.pageNumber))
+      .forEach(page => {
+        const headerElements: Element[] = page.getElementsSubset(
+          new BoundingBox(0, 0, page.width, doc.margins.top),
+        );
 
-      const footerElements: Element[] = page.getElementsSubset(
-        new BoundingBox(0, doc.margins.bottom, page.width, page.height - doc.margins.bottom),
-      );
+        const footerElements: Element[] = page.getElementsSubset(
+          new BoundingBox(0, doc.margins.bottom, page.width, page.height - doc.margins.bottom),
+        );
+        
+        for (const element of footerElements) {
+          element.properties.isFooter = true;
+        }
 
-      for (const element of footerElements) {
-        element.properties.isFooter = true;
-      }
-
-      for (const element of headerElements) {
-        element.properties.isHeader = true;
-      }
-    });
+        for (const element of headerElements) {
+          element.properties.isHeader = true;
+        }
+      });
     logger.debug('Done with marginals detection.');
     return doc;
   }

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { BoundingBox, Document, Element, Page } from '../../types/DocumentRepresentation';
+import {
+  BoundingBox,
+  Document,
+  Element,
+  Page,
+} from '../../types/DocumentRepresentation';
 import * as utils from '../../utils';
 import logger from '../../utils/Logger';
 import { Module } from '../Module';

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -48,10 +48,11 @@ export class HeaderFooterDetectionModule extends Module<Options> {
         })
         .reduce((a, b) => a + b, 0) > 0;
 
-    if (doc.pages.length === 1) {
+    let nbPageToTreat: number = this.countPageToTreat(doc.pages.length);
+    if (nbPageToTreat <= 1) {
       logger.warn(
         'Not computing marginals (headers and footers)' +
-          'the document only has 1 page (not enough data).',
+          'the document has only 1 page to check (not enough data).',
       );
       return doc;
     } else if (this.options.maxMarginPercentage === undefined) {
@@ -157,7 +158,7 @@ export class HeaderFooterDetectionModule extends Module<Options> {
         const footerElements: Element[] = page.getElementsSubset(
           new BoundingBox(0, doc.margins.bottom, page.width, page.height - doc.margins.bottom),
         );
-        
+
         for (const element of footerElements) {
           element.properties.isFooter = true;
         }
@@ -168,5 +169,15 @@ export class HeaderFooterDetectionModule extends Module<Options> {
       });
     logger.debug('Done with marginals detection.');
     return doc;
+  }
+  
+  private countPageToTreat(docLength: number): number {
+    let nbPagesToTreat: number = docLength;
+    this.options.ignorePages.forEach(p => {
+      if (p > 0 && p <= docLength) {
+        nbPagesToTreat = nbPagesToTreat - 1;
+      }
+    });
+    return nbPagesToTreat;
   }
 }

--- a/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
+++ b/server/src/processing/HeaderFooterDetectionModule/HeaderFooterDetectionModule.ts
@@ -129,8 +129,8 @@ export class HeaderFooterDetectionModule extends Module<Options> {
     );
     return true;
   }
-  private boolToInt(occupancy: boolean) : number{
-      return (occupancy? 1 : 0);
+  private boolToInt(occupancy: boolean) : number {
+      return occupancy ? 1 : 0;
   }
 
   private setMargins(

--- a/server/src/processing/HeaderFooterDetectionModule/README.md
+++ b/server/src/processing/HeaderFooterDetectionModule/README.md
@@ -26,6 +26,7 @@ The following two parameters are available:
 1. `maxMarginPercentage`: The percentage of the page up to which (both from the top and the bottom) the algorithm will search for header or footer classification.
 2. `ignorePages`: The list of pages to be ignored in the header/footer search.
    This typically includes book titles, table of contents, preface, and other pages which do not typically have the same header/footer layout as the rest of the document.
+3. `similaritySizePercentage`: The percentage represent the difference of size between pages. This allow to apply the maxMarginPercentage option within groups of pages of similar size. 
 
 ## Accuracy
 

--- a/server/src/processing/HeaderFooterDetectionModule/defaultConfig.json
+++ b/server/src/processing/HeaderFooterDetectionModule/defaultConfig.json
@@ -11,6 +11,13 @@
 				"min": 0,
 				"max": 100
 			}
+		},
+		"similaritySizePercentage": {
+			"value": 10,
+			"range": {
+				"min": 0,
+				"max": 200
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Fix ignore pages when it is set in config file.
- Treatment is now done on group of pages by similar size. This similarity size is a new option set to 10% by default.
- Treatment is done only on group of pages with more than one page.

Header and footer are set correctly within the percentage value, however the dash line on UI are still based on the margins value of the last group of page, as for now margins are a doc property and not a page property.  

Some files to test the behavior:
[multipleFormats_001.pdf](https://github.com/axa-group/Parsr/files/4895580/multipleFormats_001.pdf)
[multipleFormats_002.pdf](https://github.com/axa-group/Parsr/files/4895582/multipleFormats_002.pdf)
[multipleFormats_003.pdf](https://github.com/axa-group/Parsr/files/4895584/multipleFormats_003.pdf)

Correct behavior for header property and dash line: multipleFormats_001.pdf
<img width="1790" alt="Screenshot 2020-07-09 at 10 31 28" src="https://user-images.githubusercontent.com/30830120/87018773-00dd0880-c1d2-11ea-8244-1ec46761a2e0.png">
<img width="1790" alt="Screenshot 2020-07-09 at 10 31 59" src="https://user-images.githubusercontent.com/30830120/87018784-04708f80-c1d2-11ea-84bc-dcafbb250ba0.png">

Correct behavior for header property but not for dash line as it is based on vertical A3 format: multipleFormats_003.pdf
<img width="1790" alt="Screenshot 2020-07-09 at 10 32 55" src="https://user-images.githubusercontent.com/30830120/87018789-05a1bc80-c1d2-11ea-9af5-7687ef7c89b5.png">
<img width="1790" alt="Screenshot 2020-07-09 at 10 33 17" src="https://user-images.githubusercontent.com/30830120/87018795-063a5300-c1d2-11ea-8d53-0a8f1115b93c.png">
