### PR TITLE
Add "font" to "word" content type in json-output.md

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -126,6 +126,7 @@ The text element type is of multiple levels of subtypes:
     "id": 1028,
     "box": {/* ... */},
     "type": "word",
+    "font": 4,
     "content": [/* ... */],        // strictly Character or string type elements
     "properties": [/* ... */],
     "metadata": [/* ... */],


### PR DESCRIPTION
I guess this might also exist on "character" but I don't have an example to check with.