### PR TITLE
python client version bump to 3.2.3

### DIFF
--- a/clients/python-client/pyproject.toml
+++ b/clients/python-client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parsr-client"
-version = "3.2.2"
+version = "3.2.3"
 description = "Python client for Parsr - Transforms PDF, Documents and Images into Enriched Structured Data"
 authors = ["AXA Group Operations S.A."]
 readme = 'README.md'


### PR DESCRIPTION
Bumping python client's version to 3.2.3 to accomodate recent Readme changes before publishing to PyPi.