### PR TITLE
[json_image_src] Add the source of image in img.src

### DIFF
--- a/server/src/processing/ImageDetectionModule/ImageDetectionModule.ts
+++ b/server/src/processing/ImageDetectionModule/ImageDetectionModule.ts
@@ -28,6 +28,7 @@ import { ImageExtractor, PdfJsImageExtractor, PdfminerImageExtractor } from './e
 
 interface Options {
   ocrImages?: boolean;
+  wordsImagesSource?: boolean;
 }
 
 type DocumentImages = {
@@ -123,6 +124,9 @@ export class ImageDetectionModule extends Module<Options> {
           if (document && document.pages.length > 0) {
             const pageIndex = imagesToScan[index].pageNumber - 1;
             const resizedWords = this.scaleWordsToFitImageBox(document, imagesToScan[index].image);
+            if (this.options.wordsImagesSource === true) {
+              this.setWordPropertieSrcImage(resizedWords, document.inputFile);
+            }
             this.removeImage(doc, imagesToScan[index]);
             doc.pages[pageIndex].elements = doc.pages[pageIndex].elements.concat(resizedWords);
             doc.pages[pageIndex].pageRotation = document.pages[pageIndex].pageRotation;
@@ -143,6 +147,12 @@ export class ImageDetectionModule extends Module<Options> {
       element => element !== imageDetected.image,
     );
     document.pages[imageDetected.pageNumber - 1].elements = noImageElements;
+  }
+
+  private setWordPropertieSrcImage(imgWords: Word[], srcFile: string) {
+    imgWords.forEach(word => {
+      word.properties.srcImage = srcFile;
+    });
   }
 
   private scaleWordsToFitImageBox(document: Document, image: Image): Word[] {

--- a/server/src/processing/ImageDetectionModule/README.md
+++ b/server/src/processing/ImageDetectionModule/README.md
@@ -15,6 +15,7 @@ MuPDF: `mutool extract` is used to extract all image files from a PDF *when pdfm
 ## Parameters
 
 `ocrImages`: Allows to extract data from detected images using selected OCR. When `true`, all detected images will be replaced with data extracted by OCR.
+`wordsImagesSource`: When `true`, all word extracted by OCR will have their propertie filled by the source of the original image.
 
 ## How it works
 

--- a/server/src/processing/ImageDetectionModule/defaultConfig.json
+++ b/server/src/processing/ImageDetectionModule/defaultConfig.json
@@ -5,6 +5,10 @@
     "ocrImages": {
       "value": false,
       "range": [true, false]
+    },
+    "wordsImagesSource": {
+      "value": true,
+      "range": [true, false]
     }
   }
 }

--- a/server/src/processing/ImageDetectionModule/extractors/PdfminerImageExtractor.ts
+++ b/server/src/processing/ImageDetectionModule/extractors/PdfminerImageExtractor.ts
@@ -46,12 +46,14 @@ export class PdfminerImageExtractor extends ImageExtractor {
     if (dumpPdfData != null) {
       const assets: string[] = readdirSync(doc.assetsFolder);
       const pageIds = DumpPdf.extractPageNodeIds(dumpPdfData);
+      const srcFile: string = doc.assetsFolder;
       doc.pages.forEach((page, index) => {
         const images = page.getElementsOfType(Image, true);
         images.forEach(img => (img.enabled = true));
         if (images.length > 0) {
           this.linkImages(images, pageIds[index], dumpPdfData, index);
           this.linkXObjectWithExtensions(images, assets, index, pageIds[index]);
+          this.linkSrcImages(images, assets, srcFile);
         }
       });
 
@@ -105,6 +107,19 @@ export class PdfminerImageExtractor extends ImageExtractor {
               img.refId
             } no extension found for file ${img.xObjId}`,
           );
+        }
+      });
+  }
+
+  private linkSrcImages(images: Image[], assets: string[], srcFile: string) {
+    images
+      .filter(img => !!img.xObjId)
+      .forEach(img => {
+        const asset = assets.filter(filename => {
+          return filename.startsWith('img-' + img.xObjId.padStart(4, '0'));
+        });
+        if (asset.length === 1) {
+          img.src = srcFile + '/' + asset[0];
         }
       });
   }

--- a/server/src/types/Metadata/Properties.ts
+++ b/server/src/types/Metadata/Properties.ts
@@ -38,4 +38,5 @@ export interface Properties {
   // column left
   cl?: number;
   targetURL?: string;
+  srcImage?: string;
 }


### PR DESCRIPTION
- With pdfMiner, the source of the image is now inside of the json export (already worked with pdfjs).

Json output exemple:

```
{
  "metadata": [],
  "pages": [
    {
      "margins": { "top": 46, "left": 57 },
      "box": { "l": 0, "t": 0, "w": 720, "h": 540 },
      "rotation": { "degrees": 0, "origin": { "x": 0, "y": 0 }, "translation": { "x": 0, "y": 0 } },
      "pageNumber": 1,
      "elements": [
        {
          "id": 975,
          "type": "image",
          "properties": { "order": 0, "cr": 711.02, "cl": 10.52 },
          "metadata": [],
          "box": { "l": 17.32, "t": 2.21, "w": 27.52, "h": 55.73 },
          "src": "/var/folders/0x/05yl4x4j1nj6qsd_p9tbbh5m0000gn/T/e38cdaa736de437855f29dae9e7430/img-0032.png",
          "refId": "Im4",
          "xObjId": "32",
          "xObjExt": "png"
        },
```

- Add an option to enable to set the source of the image inside the properties of extracted data from ocr.

Json output exemple:

```
        {
          "id": 47093,
          "type": "heading",
          "properties": { "order": 0 },
          "metadata": [],
          "box": { "l": 18.87, "t": 5.35, "w": 24.12, "h": 50.23 },
          "content": [
            {
              "id": 46103,
              "type": "line",
              "properties": { "order": 0, "cr": 711.02, "cl": 10.52 },
              "metadata": [],
              "box": { "l": 18.87, "t": 5.35, "w": 24.12, "h": 50.23 },
              "content": [
                {
                  "id": 11304,
                  "type": "word",
                  "properties": {
                    "srcImage": "/var/folders/0x/05yl4x4j1nj6qsd_p9tbbh5m0000gn/T/f3d0728a1a1428e90ee952de4bf4f1/img-0032.png",
                    "order": 0
                  },
                  "metadata": [],
                  "box": { "l": 18.87, "t": 5.35, "w": 24.12, "h": 50.23 },
                  "conf": 12,
                  "content": "ST:",
                  "font": 1
                }
              ]
            }
          ],
          "level": 1
        },
```

- Update the documentation README.md.