### PR TITLE
[fix parsr_client #498] Fix indentation in client GET requests

### DIFF
--- a/clients/python-client/parsr_client/parsr_client.py
+++ b/clients/python-client/parsr_client/parsr_client.py
@@ -269,7 +269,7 @@ class ParsrClient():
         return responses
 
     def get_status(self, request_id: str = "", server: str = ""):
-        """Get the status of a partcular request using its ID
+        """Get the status of a particular request using its ID
 
         - request_id: The ID of the request to be queried with the server
         - server: The server address where the query is to be made
@@ -310,8 +310,8 @@ class ParsrClient():
                 raise Exception('No request ID provided')
             else:
                 request_id = self.request_id
-                r = get(
-                    'http://{}/api/v1/json/{}'.format(server, request_id))
+        r = get(
+            'http://{}/api/v1/json/{}'.format(server, request_id))
         if r.text != "":
             return r.json()
         else:
@@ -334,8 +334,8 @@ class ParsrClient():
                 raise Exception('No request ID provided')
             else:
                 request_id = self.request_id
-                r = get(
-                    'http://{}/api/v1/markdown/{}'.format(server, request_id))
+        r = get(
+            'http://{}/api/v1/markdown/{}'.format(server, request_id))
         if r.text != "":
             return r.text
         else:
@@ -358,8 +358,8 @@ class ParsrClient():
                 raise Exception('No request ID provided')
             else:
                 request_id = self.request_id
-                r = get(
-                    'http://{}/api/v1/text/{}'.format(server, request_id))
+        r = get(
+            'http://{}/api/v1/text/{}'.format(server, request_id))
         if r.text != "":
             return r.text
         else:


### PR DESCRIPTION
> The context of this PR is laid out in full in #498 

This PR allows the python client parsr_client.ParsrClient to support a specified `request_id`, on occasions when `save_request_id` is false. Currently, if a specific ID is provided in output methods like `get_json()` and `get_markdown()`, an `UnboundLocalError` is raised.

I think this is due to an indentation error that means the get request from the server is only issued if no `request_id` is provided.

The error does not occur with get_status() which is an identical GET implementation but for the indentation of this request line.

### Worklist

- [x] Fork, branch, PR as per contribution guidelines (I think?!)
- [x] Fix indentation
- [ ] Add unit tests?

It would seem sensible to add unit tests here, but there aren't currently other tests in place for the python client. I can try and work on some general tests in this space, but that'd significantly extend the time to delivery of this PR!

Let me know if this needs reworking or abandoning--I hope these contributions are not unwanted or rude!