### PR TITLE
Replace legacy vue-markdown with marked

### DIFF
--- a/demo/vue-viewer/package-lock.json
+++ b/demo/vue-viewer/package-lock.json
@@ -1233,6 +1233,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -2496,11 +2497,6 @@
           }
         }
       }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -3817,7 +3813,8 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -4982,7 +4979,8 @@
     "highlight.js": {
       "version": "9.18.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
+      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -5901,14 +5899,6 @@
         "verror": "1.10.0"
       }
     },
-    "katex": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.6.0.tgz",
-      "integrity": "sha1-EkGOCRIcBckgQbazuftrqyE8tvM=",
-      "requires": {
-        "match-at": "^0.1.0"
-      }
-    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -5954,14 +5944,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
-    },
-    "linkify-it": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz",
-      "integrity": "sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=",
-      "requires": {
-        "uc.micro": "^1.0.1"
-      }
     },
     "loader-fs-cache": {
       "version": "1.0.3",
@@ -6115,84 +6097,10 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-it": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.1.1.tgz",
-      "integrity": "sha1-ztA39Ec+6fUVOsQU933IPJG6knw=",
-      "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~1.1.1",
-        "linkify-it": "~1.2.2",
-        "mdurl": "~1.0.1",
-        "uc.micro": "^1.0.1"
-      }
-    },
-    "markdown-it-abbr": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-abbr/-/markdown-it-abbr-1.0.4.tgz",
-      "integrity": "sha1-1mtTZFIcuz3Yqlna37ovtoZcj9g="
-    },
-    "markdown-it-deflist": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.0.3.tgz",
-      "integrity": "sha512-/BNZ8ksW42bflm1qQLnRI09oqU2847Z7MVavrR0MORyKLtiUYOMpwtlAfMSZAQU9UCvaUZMpgVAqoS3vpToJxw=="
-    },
-    "markdown-it-emoji": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",
-      "integrity": "sha1-m+4OmpkKljupbfaYDE/dsF37Tcw="
-    },
-    "markdown-it-footnote": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-2.0.0.tgz",
-      "integrity": "sha1-FOnE9o/xLPNU+jZa43gnboEEypQ="
-    },
-    "markdown-it-ins": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-ins/-/markdown-it-ins-2.0.0.tgz",
-      "integrity": "sha1-papqMPHi9x6Ul1Z8/f9A8f3mdIM="
-    },
-    "markdown-it-katex": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-it-katex/-/markdown-it-katex-2.0.3.tgz",
-      "integrity": "sha1-17hqGuoLnWSW+rTnkZoY/e9YnDk=",
-      "requires": {
-        "katex": "^0.6.0"
-      }
-    },
-    "markdown-it-mark": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-2.0.0.tgz",
-      "integrity": "sha1-RqGqlHEFrtgYiXjgoBYXnkBPQsc="
-    },
-    "markdown-it-sub": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-1.0.0.tgz",
-      "integrity": "sha1-N1/WAm6ufdywEkl/ZBEZXqHjr+g="
-    },
-    "markdown-it-sup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz",
-      "integrity": "sha1-y5yf+RpSVawI8/09YyhuFd8KH8M="
-    },
-    "markdown-it-task-lists": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
-      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="
-    },
-    "markdown-it-toc-and-anchor": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-toc-and-anchor/-/markdown-it-toc-and-anchor-4.2.0.tgz",
-      "integrity": "sha512-DusSbKtg8CwZ92ztN7bOojDpP4h0+w7BVOPuA3PHDIaabMsERYpwsazLYSP/UlKedoQjOz21mwlai36TQ04EpA==",
-      "requires": {
-        "clone": "^2.1.0",
-        "uslug": "^1.0.4"
-      }
-    },
-    "match-at": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/match-at/-/match-at-0.1.1.tgz",
-      "integrity": "sha512-h4Yd392z9mST+dzc+yjuybOGFNOZjmXIPKWjxBd1Bb23r4SmDOsk2NYCU2BMUBGbSpZqwVsZYNq26QS3xfaT3Q=="
+    "marked": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
+      "integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA=="
     },
     "material-design-icons-iconfont": {
       "version": "5.0.1",
@@ -6216,11 +6124,6 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
       "dev": true
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -9147,7 +9050,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -9768,11 +9672,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-    },
     "uglify-js": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -9844,11 +9743,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
-    },
-    "unorm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -9998,14 +9892,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "uslug": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/uslug/-/uslug-1.0.4.tgz",
-      "integrity": "sha1-uaIvCRTgqGFAYz2swwLl9PpFBnc=",
-      "requires": {
-        "unorm": ">= 1.0.0"
-      }
     },
     "util": {
       "version": "0.11.1",
@@ -10177,26 +10063,6 @@
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         }
-      }
-    },
-    "vue-markdown": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/vue-markdown/-/vue-markdown-2.2.4.tgz",
-      "integrity": "sha512-hoTX/W1UIdHZrp/b0vpHSsJXAEfWsafaQLgtE2VX4gY8O/C3L2Gabqu95gyG429rL4ML1SwGv+xsPABX7yfFIQ==",
-      "requires": {
-        "highlight.js": "^9.12.0",
-        "markdown-it": "^6.0.1",
-        "markdown-it-abbr": "^1.0.3",
-        "markdown-it-deflist": "^2.0.1",
-        "markdown-it-emoji": "^1.1.1",
-        "markdown-it-footnote": "^2.0.0",
-        "markdown-it-ins": "^2.0.0",
-        "markdown-it-katex": "^2.0.3",
-        "markdown-it-mark": "^2.0.0",
-        "markdown-it-sub": "^1.0.0",
-        "markdown-it-sup": "^1.0.0",
-        "markdown-it-task-lists": "^2.0.1",
-        "markdown-it-toc-and-anchor": "^4.1.2"
       }
     },
     "vue-observe-visibility": {

--- a/demo/vue-viewer/package.json
+++ b/demo/vue-viewer/package.json
@@ -10,10 +10,10 @@
   "dependencies": {
     "axios": "^0.19.2",
     "core-js": "^2.6.5",
+    "marked": "^1.2.0",
     "sass": "^1.26.3",
     "sass-loader": "^7.1.0",
     "vue": "^2.6.11",
-    "vue-markdown": "^2.2.4",
     "vue-observe-visibility": "^0.4.6",
     "vue-router": "^3.1.6",
     "vuetify": "^2.2.17",

--- a/demo/vue-viewer/src/views/ViewerMarkdown.vue
+++ b/demo/vue-viewer/src/views/ViewerMarkdown.vue
@@ -11,10 +11,10 @@
       <v-tab>Render</v-tab>
 
       <v-tab-item class="tabItem">
-        <pre class="text">{{ documentMarkdown }}</pre>
+        <pre class="text">{{ compiledMarkdown }}</pre>
       </v-tab-item>
       <v-tab-item class="tabItem">
-        <vueMarkdown class="text">{{ documentMarkdown }}</vueMarkdown>
+        <vueMarkdown class="text">{{ compiledMarkdown }}</vueMarkdown>
       </v-tab-item>
     </v-tabs>
 
@@ -42,19 +42,21 @@
 </template>
 <script>
 import { mapState } from 'vuex';
-import VueMarkdown from 'vue-markdown';
+import marked from 'marked';
 
 export default {
   data() {
     return { error: null };
   },
-  components: { VueMarkdown },
   computed: {
     uploadedDocument() {
       return this.documentId !== null;
     },
     documentMarkdownFetched() {
-      return this.documentMarkdown !== null;
+      return this.compiledMarkdown !== null;
+    },
+    compiledMarkdown: function() {
+      return marked(this.documentMarkdown, { sanitize: true });
     },
     ...mapState({
       documentId: state => state.uuid,


### PR DESCRIPTION
Change frontend markdown renderer to `marked` from `vue-markdown` because the latter had major security issues and is no longer maintained.