### PR TITLE
Pinned scikit-learn version; fixed opencv-python installation taking longer than neccessary

### DIFF
--- a/docker/parsr-base/Dockerfile
+++ b/docker/parsr-base/Dockerfile
@@ -17,7 +17,8 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 RUN apt-get update && \
   apt-get install -y imagemagick mupdf mupdf-tools qpdf pandoc tesseract-ocr-all nodejs npm python-pdfminer python-pip python3-pip python-tk python3-pdfminer python3-opencv && \
   pip install PyPDF2 && \
-  pip3 install ghostscript PyPDF2 camelot-py[cv] numpy pillow sklearn tabula-py
+  pip3 install --upgrade setuptools pip && \
+  pip3 install opencv-python ghostscript PyPDF2 camelot-py[cv] numpy pillow scikit-learn==0.23.2 tabula-py
 
 ADD policy.xml /etc/ImageMagick-6/policy.xml
 


### PR DESCRIPTION
- Pinned scikit-learn to match the version (0.23.2) of the pickled model training data provided with the server. Up until now, the build scripts downloaded the latest version (0.24.2 as of today) which causes the server to crash on heading detection (see https://scikit-learn.org/stable/modules/model_persistence.html) -> **Another possibility might be to resolve this dependency in the parsr image (as opposed to parsr-base) if frequent updates are intended, but I didn't introduce that change**

- Fixed installation of opencv-python taking unnecessarily long (it was supposedly being compiled on install; see https://github.com/3b1b/manim/issues/1213)

- Tested building images from scratch, run without errors