### PR TITLE
Add page number to simple json output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.kdev4
+*.kate-swp
+
 # General
 .DS_Store
 .AppleDouble

--- a/server/src/output/simpleJson/SimpleJsonExporter.ts
+++ b/server/src/output/simpleJson/SimpleJsonExporter.ts
@@ -40,7 +40,7 @@ export class SimpleJsonExporter extends Exporter {
 
   private getSimpleJSON(): string {
     const simpleJSON = [];
-    this.doc.pages.forEach((page) => {
+    this.doc.pages.forEach((page, pageN) => {
       page.elements.forEach(element => {
         if (
           (element.properties.isHeader || element.properties.isFooter) &&
@@ -48,6 +48,7 @@ export class SimpleJsonExporter extends Exporter {
         ) {
           return;
         }
+        element.page = pageN;
         if (element instanceof Heading) {
           simpleJSON.push(element.toSimpleJSON());
         } else if (element instanceof Paragraph) {

--- a/server/src/types/DocumentRepresentation/Element.ts
+++ b/server/src/types/DocumentRepresentation/Element.ts
@@ -197,6 +197,22 @@ export abstract class Element {
     this.globalId = 1;
   }
 
+  /**
+   * Getter page
+   * @return {number}
+   */
+  public get page(): number {
+    return this._page;
+  }
+
+  /**
+   * Setter page
+   * @param {number} value
+   */
+  public set page(value: number) {
+    this._page= value;
+  }
+
   private static globalId = 1;
   private _id: number;
   private _metadata: Metadata[];
@@ -204,6 +220,7 @@ export abstract class Element {
   private _parent: Element;
   private _children: Element[];
   private _box?: BoundingBox;
+  private _page: number;
 
   constructor(box?: BoundingBox) {
     this._id = Element.globalId++;

--- a/server/src/types/DocumentRepresentation/Heading.ts
+++ b/server/src/types/DocumentRepresentation/Heading.ts
@@ -71,6 +71,7 @@ export class Heading extends Paragraph {
       type : 'heading',
       level : this.level,
       content : this.toString(),
+      page: this.page,
     };
   }
 }

--- a/server/src/types/DocumentRepresentation/List.ts
+++ b/server/src/types/DocumentRepresentation/List.ts
@@ -122,6 +122,7 @@ export class List extends Element {
     return {
       type : 'list',
       content : this.export('simple'),
+      page: this.page,
     };
   }
 

--- a/server/src/types/DocumentRepresentation/Paragraph.ts
+++ b/server/src/types/DocumentRepresentation/Paragraph.ts
@@ -74,6 +74,7 @@ export class Paragraph extends Text {
     return {
       type: 'paragraph',
       content: this.export('simple'),
+      page: this.page,
     };
   }
 

--- a/server/src/types/DocumentRepresentation/Table.ts
+++ b/server/src/types/DocumentRepresentation/Table.ts
@@ -336,6 +336,7 @@ export class Table extends Element {
     return {
       type: 'table',
       content: output,
+      page: this.page,
     };
   }
 

--- a/server/src/types/DocumentRepresentation/TableOfContents.ts
+++ b/server/src/types/DocumentRepresentation/TableOfContents.ts
@@ -62,6 +62,7 @@ export class TableOfContents extends Element {
     return {
       type : 'tableOfContent',
       content : this.items.map(c => c.toString()),
+      page: this.page,
     };
   }
 


### PR DESCRIPTION
This adds page number to simple json outputs in headings, paragraphs, tables, etc. This allows an application handling text to show the original pdf page, possibly with annotations.