### PR TITLE
[documentation] update example config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,7 +220,7 @@ The `includeDrawings: boolean` parameter specifies if json output should contain
     ["header-footer-detection", { "maxMarginPercentage": 15 }],
     ["reading-order-detection", { "minColumnWidthInPagePercent": 15 }],
     "link-detection",
-    ["words-to-line", { "maximumSpaceBetweenWords": 100 }],
+    ["words-to-line-new", { "maximumSpaceBetweenWords": 100 }],
     "lines-to-paragraph",
     "page-number-detection",
     "hierarchy-detection",


### PR DESCRIPTION
Updated to the new version of words-to-line module. The old example produces the same error as in #493:

```
/opt/app-root/src/dist/src/Cleaner.js:201
            throw new Error("Module " + moduleClass.moduleName + " has unresolved dependencies (" + unresolvedStr + ").");
            ^

Error: Module lines-to-paragraph has unresolved dependencies (words-to-line-new).
    at Cleaner.checkDependenciesAndAdd (/opt/app-root/src/dist/src/Cleaner.js:201:19)
    at /opt/app-root/src/dist/src/Cleaner.js:136:19
    at Array.forEach (<anonymous>)
    at Cleaner.parseLatestConfig (/opt/app-root/src/dist/src/Cleaner.js:123:16)
    at new Cleaner (/opt/app-root/src/dist/src/Cleaner.js:88:18)
    at main (/opt/app-root/src/dist/bin/index.js:72:19)
    at Object.<anonymous> (/opt/app-root/src/dist/bin/index.js:204:1)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)

```